### PR TITLE
Add detecting mouth speaking

### DIFF
--- a/mouth/main.py
+++ b/mouth/main.py
@@ -1,0 +1,64 @@
+import cv2
+import dlib
+import numpy as np
+
+PREDICOTR_PATH = "./shape_predictor_68_face_landmarks.dat"
+
+def annotate_landmarks(img, landmarks):
+    img = img.copy()
+    for idx, point in enumerate(landmarks):
+        pos = (point[0, 0], point[0, 1])
+        cv2.putText(img, str(idx), pos,
+            fontFace=cv2.FONT_HERSHEY_SCRIPT_SIMPLEX,
+            fontScale=0.4,
+            color=(1, 2, 255))
+        cv2.circle(img, pos, 3, color=(0, 2, 2))
+    return img
+
+def centor(pts):
+    lip_mean = np.mean(pts, axis=0)
+    return int(lip_mean[:, 1])
+
+
+def detect_speaking(img):
+    rects = detector(img, 1)
+    if len(rects) != 1:
+        return img, 0
+    landmarks = np.matrix([[p.x, p.y] for p in predictor(img, rects[0]).parts()])
+
+    img_with_landmarks = annotate_landmarks(img, landmarks)
+
+    top_lip_centor = centor(landmarks[50:53] + landmarks[61:64])
+    bottom_lip_centor = centor(landmarks[65:68] + landmarks[56:59])
+    lip_distance = abs(top_lip_centor - bottom_lip_centor)
+
+    return img_with_landmarks, lip_distance
+
+
+predictor = dlib.shape_predictor(PREDICOTR_PATH)
+detector = dlib.get_frontal_face_detector()
+
+cap = cv2.VideoCapture(0)
+yawn_status = False
+lip_distance_list = list()
+
+while True:
+    ret, frame = cap.read()
+    img_with_landmarks, lip_distance = detect_speaking(frame)
+    # lip_distance_list = lip_distance[:19] + [lip_distance] # Not Use right now.
+
+    # TODO. replace constant to dynamic value calculated from mouth size.
+    if lip_distance > 45:
+        yawn_status = True        
+        cv2.putText(frame, "Please, close the mouth for COVID-19", (50, 400), cv2.FONT_HERSHEY_COMPLEX, 1, (0, 0, 255), 2)
+    else:
+        yawn_status = False
+
+    # cv2.imshow("Live landmarks", img_with_landmarks)
+    cv2.imshow("Yawn status", frame)
+
+    if cv2.waitKey(1) == 13:
+        break
+
+cap.release()
+cv2.destroyAllWindows()

--- a/mouth/main.py
+++ b/mouth/main.py
@@ -15,7 +15,7 @@ def annotate_landmarks(img, landmarks):
         cv2.circle(img, pos, 3, color=(0, 2, 2))
     return img
 
-def centor(pts):
+def center(pts):
     lip_mean = np.mean(pts, axis=0)
     return int(lip_mean[:, 1])
 
@@ -28,9 +28,9 @@ def detect_speaking(img):
 
     img_with_landmarks = annotate_landmarks(img, landmarks)
 
-    top_lip_centor = centor(landmarks[50:53] + landmarks[61:64])
-    bottom_lip_centor = centor(landmarks[65:68] + landmarks[56:59])
-    lip_distance = abs(top_lip_centor - bottom_lip_centor)
+    top_lip_center = center(landmarks[50:53] + landmarks[61:64])
+    bottom_lip_center = center(landmarks[65:68] + landmarks[56:59])
+    lip_distance = abs(top_lip_center - bottom_lip_center)
 
     return img_with_landmarks, lip_distance
 


### PR DESCRIPTION
# 방향성
- `shape_predictor_68_face_landmarks.dat` 는 root dir 에 두고 사용
- 일단 각 dir 에서 휴리스틱 테스트하고 완성되면 `frame` 받아서 작업하는 함수로 만들어놓고 main.py 에서 call 하는 방향

# 작업
dlib 에서 제공되는 landscape 기반하여 (50~52, 61~63), (65 ~ 67, 56 ~ 58) 을 기준으로 top, bottom lip centor 를 구하고 distance 측정 후, 특정 threshold 를 넘어가면 `mouth open` 으로 인지

# TODO
- threshold 를 단순 상수가 아닌 mouth size 기반하여 새로 정의
- 이전 history 에 따라 말하고 있는 입인지 단순히 벌리고 있는 입인지 구분 (이게 의미가 있는지는 좀 더 고민)