### PR TITLE
alert

### DIFF
--- a/alert/main.py
+++ b/alert/main.py
@@ -1,0 +1,360 @@
+'''
+code partly from https://livecodestream.dev/post/2020-07-03-detecting-face-features-with-python/
+             and https://docs.opencv.org/3.4/db/d28/tutorial_cascade_classifier.html
+'''
+import sys
+import cv2
+import dlib
+import numpy as np
+
+CASC_DIR = '../cascade/'
+
+# valid distance to a mouth relative to the nose from an eye
+MOUTH_POS_REL_NOSE_FROM_EYE_COEF = 2
+
+def get_degree(vec1, vec2):
+    ''' get degree '''
+    return np.arccos(np.clip(vec1.dot(vec2),-1.0,1.0))*180/np.pi
+
+def show_result(frame,proper):
+    ''' show result '''
+    str_result = 'Alert!'
+    text_color = (0,0,255)
+    # detected = ''
+    if proper:
+        str_result = 'Good'
+        text_color = (0,255,0)
+    # else:
+    #     if nose:
+    #         detected += 'nose '
+    #     elif mouth:
+    #         detected += 'mouth '
+    #     if detected != '':
+    #         detected += 'detected'
+
+    cv2.putText(frame, str_result, (50,50), cv2.FONT_HERSHEY_DUPLEX, 1, text_color, 2)
+    # if not proper:
+    #     cv2.putText(frame, detected, (150,50), cv2.FONT_HERSHEY_SIMPLEX, 1, (71,99,255), 2)
+
+    # show the image
+    cv2.imshow("Mask Alert", frame)
+
+    # Exit when escape is pressed
+    stop = (cv2.waitKey(delay=1) == 27)
+    return stop
+
+def run_landmark(detector, predictor, nose_cascade, frame, frame_gray): # pylint: disable=too-many-locals
+    ''' run landmark '''
+    # Use detector to find landmarks
+    faces = detector(frame_gray)
+
+    proper = True
+    # face found
+    if len(faces) != 0:
+        for face in faces:
+            f_x = face.left()  # left point
+            f_y = face.top()  # top point
+            f_w = face.right()-f_x  # right point
+            f_h = face.bottom()-f_y  # bottom point
+            # Create landmark object
+            landmarks = predictor(image=frame_gray, box=face)
+            # Loop through all the points
+            for num in range(0, 68):
+                pos = (landmarks.part(num).x,landmarks.part(num).y)
+                # Draw a circle
+                if num==30:
+                    cv2.circle(img=frame, center=pos, radius=3, color=(0, 0, 255), thickness=-1)
+                else:
+                    cv2.circle(img=frame, center=pos, radius=3, color=(0, 255, 0), thickness=-1)
+
+            face_center = np.array([f_x + f_w//2, f_y + f_h//2])
+            frame = cv2.ellipse(frame,tuple(face_center),(f_w//2,f_h//2),0,0,360,(255,0,255),4)
+            face_roi = frame_gray[f_y:f_y+f_h,f_x:f_x+f_w]
+
+            noses = nose_cascade.detectMultiScale(face_roi)
+            for (in_x,in_y,in_w,in_h) in noses:
+                nose_center = np.array([f_x + in_x + in_w//2, f_y + in_y + in_h//2])
+                radius = int(round((in_w + in_h)*0.25))
+                if np.sum((nose_center-face_center)**2) > radius**2:
+                    continue
+                proper = False
+                frame = cv2.circle(frame, tuple(nose_center), radius, (255, 255, 0), 4)
+
+            # if not proper:
+            #     mouth = nose = True
+
+    found_face = (len(faces)!=0)
+
+    return found_face,frame,proper
+
+def bad_distance(coo,valid_nose,min_sq_dist):
+    ''' bad distance '''
+    if valid_nose is not None:
+        valid_nose = np.array(valid_nose[:2])
+        bad = np.sum((coo-valid_nose)**2) > MOUTH_POS_REL_NOSE_FROM_EYE_COEF*min_sq_dist
+        return bad
+    return False
+
+def handle_degree(args):
+    ''' handle degree '''
+    frame,mid_eye,center,sub_eye,in_w,in_h,proper = args
+    to_mid_eye = mid_eye-center
+    to_mid_eye = to_mid_eye/np.linalg.norm(to_mid_eye)
+    degree = get_degree(sub_eye,to_mid_eye)
+    # print(degree)
+    if abs(degree-90)<30:
+        radius = int(round((in_w + in_h)*0.25))
+        frame = cv2.circle(frame, tuple(center), radius, (255, 255, 0), 4)
+        proper = False
+    return frame,proper
+
+def handle_degree_and_dist(args):
+    ''' handle degree and distance'''
+    frame,mid_eye,center,sub_eye,lower_eye,dist_sq_eye,in_w,in_h,proper = args
+
+    to_mid_eye = mid_eye-center
+    to_mid_eye = to_mid_eye/np.linalg.norm(to_mid_eye)
+    degree = get_degree(sub_eye,to_mid_eye)
+    dist_one_eye = np.sum((center-lower_eye)**2)
+    # print(degree)
+    if abs(degree-90)<30 and dist_one_eye>dist_sq_eye:
+        radius = int(round((in_w + in_h)*0.25))
+        frame = cv2.circle(frame, tuple(center), radius, (0, 255, 0), 4)
+        proper = False
+    return frame,proper
+
+def run_face_cascade(args): # pylint: disable=too-many-locals
+    ''' run face cascade '''
+    face_cascade,eyes_cascade,nose_cascade,mouth_cascade,frame,frame_gray = args
+    proper = True
+    faces = face_cascade.detectMultiScale(frame_gray)
+    for (f_x,f_y,f_w,f_h) in faces:
+        center = (f_x + f_w//2, f_y + f_h//2)
+        frame = cv2.ellipse(frame, center, (f_w//2, f_h//2), 0, 0, 360, (255, 0, 255), 4)
+        face_roi = frame_gray[f_y:f_y+f_h,f_x:f_x+f_w]
+
+        eye_lower_center = -1
+        #-- In each face, detect eyes
+        eyes = eyes_cascade.detectMultiScale(face_roi)
+        for (in_x,in_y,in_w,in_h) in eyes:
+            eye_center = (f_x + in_x + in_w//2, f_y + in_y + in_h//2)
+            radius = int(round((in_w + in_h)*0.25))
+            frame = cv2.circle(frame, eye_center, radius, (255, 0, 0), 4)
+
+            lowest_eye = max(eyes, key=lambda x:x[1])
+            eye_lower_center = lowest_eye[1]+lowest_eye[3]
+
+        noses = nose_cascade.detectMultiScale(face_roi)
+        for (in_x,in_y,in_w,in_h) in noses:
+            if in_y+in_h/2 < eye_lower_center:
+                continue
+            proper = False
+            # nose = True
+            nose_center = (f_x + in_x + in_w//2, f_y + in_y + in_h//2)
+            radius = int(round((in_w + in_h)*0.25))
+            frame = cv2.circle(frame, nose_center, radius, (255, 255, 0), 4)
+
+        mouths = mouth_cascade.detectMultiScale(face_roi)
+        for (in_x,in_y,in_w,in_h) in mouths:
+            if in_y < eye_lower_center:
+                continue
+            proper = False
+            # mouth = True
+            mouth_center = (f_x + in_x + in_w//2, f_y + in_y + in_h//2)
+            radius = int(round((in_w + in_h)*0.25))
+            frame = cv2.circle(frame, mouth_center, radius, (0, 255, 0), 4)
+
+        if proper:
+            break
+
+    found_face = (len(faces)!=0)
+
+    return found_face,frame,proper
+
+def process_eyes(eyes,frame):
+    ''' process_eyes '''
+    eye_lower_center = -1
+    sum_center = [0, 0]
+    lower_eye = None
+    np.array(eyes[0][:2])
+
+    for (e_x,e_y,e_w,e_h) in eyes:
+        center = (e_x + e_w//2, e_y + e_h//2)
+        radius = int(round((e_w + e_h)*0.25))
+        frame = cv2.circle(frame, center, radius, (255, 0, 0), 4)
+
+        if eye_lower_center < center[1]:
+            eye_lower_center = center[1]
+            lower_eye = np.array(center)
+
+        sum_center[0] += center[0]
+        sum_center[1] += center[1]
+
+    return eye_lower_center,sum_center,lower_eye,frame
+
+def run_eye_cascade(args): # pylint: disable=too-many-locals
+    ''' run eye cascade '''
+    eyes_cascade,nose_cascade,mouth_cascade,frame,frame_gray = args
+    eyes = eyes_cascade.detectMultiScale(frame_gray)
+
+    if len(eyes)==0:
+        found_eye = False
+        return found_eye,frame,None
+
+    eye_lower_center,sum_center,lower_eye,frame = process_eyes(eyes,frame)
+
+    proper = True
+    valid_nose = None
+    min_sq_dist = 10**8
+    mid_eye = None
+    sub_eye = None
+    dist_sq_eye = None
+
+    # to check if detected noses and mouths are in valid position
+    if len(eyes)==2:
+        mid_eye = np.array([sum_center[0]/2, sum_center[1]/2])
+        sub_eye = np.array([eyes[1][0]-eyes[0][0], eyes[1][1]-eyes[0][1]])
+        dist_sq_eye = np.sum(sub_eye*sub_eye)
+        sub_eye = sub_eye/np.linalg.norm(sub_eye)
+
+    lower_roi = frame_gray[eye_lower_center:,:]
+    noses = nose_cascade.detectMultiScale(lower_roi)
+    for (in_x,in_y,in_w,in_h) in noses:
+        if (in_x-lower_eye[0])**2 + in_y**2 < min_sq_dist:
+            valid_nose = (in_x,in_y,in_w,in_h)
+
+    if valid_nose is not None:
+        in_x,in_y,in_w,in_h = valid_nose
+        nose_center = np.array([in_x + in_w//2, lower_eye[1] + in_y + in_h//2])
+
+        if mid_eye is not None:
+            # print('nose')
+            args = (frame,mid_eye,nose_center,sub_eye,in_w,in_h,proper)
+            frame,proper = handle_degree(args)
+            # frame,proper,nose = handle_degree(frame,mid_eye,nose_center,sub_eye)
+        else:
+            proper = False
+            # nose = True
+            radius = int(round((in_w + in_h)*0.25))
+            frame = cv2.circle(frame, tuple(nose_center), radius, (255, 255, 0), 4)
+
+    mouths = mouth_cascade.detectMultiScale(lower_roi)
+    for (in_x,in_y,in_w,in_h) in mouths:
+
+        if bad_distance(np.array([in_x,in_y]),valid_nose,min_sq_dist):
+            continue
+
+        mouth_center = np.array([in_x + in_w//2, lower_eye[1] + in_y + in_h//2])
+
+        if mid_eye is not None:
+            # print('mouth')
+            coo = (in_w,in_h)
+            args = (frame,mid_eye,mouth_center,sub_eye,lower_eye,dist_sq_eye,*coo,proper)
+            frame,proper = handle_degree_and_dist(args)
+            # frame,proper,mouth = handle_degree_and_dist(args)
+
+        else:
+            proper = False
+            # mouth = True
+            radius = int(round((in_w + in_h)*0.25))
+            frame = cv2.circle(frame, tuple(mouth_center), radius, (0, 255, 0), 4)
+
+    found_eye = True
+    return found_eye,frame,proper
+
+def run(resources):
+    ''' run '''
+    (detector,predictor), (face_cascade,eyes_cascade,mouth_cascade,nose_cascade), cap = resources
+    while True:
+        _,frame = cap.read()
+        if frame is None:
+            print('--(!) No captured frame -- Break!')
+            break
+
+        # Convert image into grayscale
+        frame_gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        # frame_gray = cv2.equalizeHist(frame_gray)
+
+        proper = False
+        # nose = mouth = False
+
+        found_face,frame,proper = run_landmark(detector,predictor,nose_cascade,frame,frame_gray)
+        # face not found through detector
+        if not found_face:
+            args = (face_cascade,eyes_cascade,nose_cascade,mouth_cascade,frame,frame_gray)
+            found_face,frame,proper = run_face_cascade(args)
+
+            # face not found through cascade
+            if not found_face:
+                args = (eyes_cascade,nose_cascade,mouth_cascade,frame,frame_gray)
+                found_eye,frame,proper = run_eye_cascade(args)
+
+                # eye not found
+                if not found_eye:
+                    proper = True
+                    # noses = nose_cascade.detectMultiScale(frame_gray)
+                    # for (x,y,w,h) in noses:
+                    #     nose = True
+                    #     center = (x + w//2, y + h//2)
+                    #     radius = int(round((w + h)*0.25))
+                    #     frame = cv2.circle(frame, center, radius, (255, 255, 0), 4)
+                    # mouths = mouth_cascade.detectMultiScale(frame_gray)
+                    # for (x,y,w,h) in mouths:
+                    #     mouth = True
+                    #     center = (x + w//2, y + h//2)
+                    #     radius = int(round((w + h)*0.25))
+                    #     frame = cv2.circle(frame, center, radius, (0, 255, 0), 4)
+
+        if show_result(frame,proper):
+            break
+
+def load():
+    ''' load '''
+    # Load the detector
+    detector = dlib.get_frontal_face_detector() # pylint: disable=no-member
+    # Load the predictor
+    predictor = dlib.shape_predictor("../landmark/shape_predictor_68_face_landmarks.dat") # pylint: disable=no-member
+    # Read the image
+    cap = cv2.VideoCapture(0, cv2.CAP_DSHOW)
+
+    face_cascade_name = CASC_DIR+'data/haarcascades/haarcascade_frontalface_alt.xml'
+    eyes_cascade_name = CASC_DIR+'data/haarcascades/haarcascade_eye_tree_eyeglasses.xml'
+    mouth_cascade_name = CASC_DIR+'data/haarcascades/haarcascade_mcs_mouth.xml'
+    nose_cascade_name = CASC_DIR+'data/haarcascades/Nariz.xml'
+    face_cascade = cv2.CascadeClassifier()
+    eyes_cascade = cv2.CascadeClassifier()
+    mouth_cascade = cv2.CascadeClassifier()
+    nose_cascade = cv2.CascadeClassifier()
+
+    # Load the cascades
+    if not face_cascade.load(cv2.samples.findFile(face_cascade_name)): # pylint: disable=maybe-no-member
+        print('--(!)Error loading face cascade')
+        sys.exit(1)
+    if not eyes_cascade.load(cv2.samples.findFile(eyes_cascade_name)): # pylint: disable=maybe-no-member
+        print('--(!)Error loading eyes cascade')
+        sys.exit(1)
+    if not mouth_cascade.load(cv2.samples.findFile(mouth_cascade_name)): # pylint: disable=maybe-no-member
+        print('--(!)Error loading eyes cascade')
+        sys.exit(1)
+    if not nose_cascade.load(cv2.samples.findFile(nose_cascade_name)): # pylint: disable=maybe-no-member
+        print('--(!)Error loading eyes cascade')
+        sys.exit(1)
+
+    return (detector,predictor), (face_cascade,eyes_cascade,mouth_cascade,nose_cascade), cap
+
+def finish(resources):
+    ''' finish '''
+    _,_,cap = resources
+    # When everything done, release the video capture and video write objects
+    cap.release()
+    # Close all windows
+    cv2.destroyAllWindows()
+
+def main():
+    ''' main '''
+    resources = load()
+    run(resources)
+    finish(resources)
+
+if __name__ == "__main__":
+    main()

--- a/cascade/c.py
+++ b/cascade/c.py
@@ -17,6 +17,11 @@ def detectAndDisplay(frame):
         center = (x + w//2, y + h//2)
         radius = int(round((w + h)*0.25))
         frame = cv.circle(frame, center, radius, (255, 0, 0 ), 4)
+    noses = nose_cascade.detectMultiScale(frame_gray)
+    for (x,y,w,h) in noses:
+        center = (x + w//2, y + h//2)
+        radius = int(round((w + h)*0.25))
+        frame = cv.circle(frame, center, radius, (255, 255, 0), 4)
     mouths = mouth_cascade.detectMultiScale(frame_gray)
     for (x,y,w,h) in mouths:
         center = (x + w//2, y + h//2)
@@ -27,14 +32,19 @@ parser = argparse.ArgumentParser(description='Code for Cascade Classifier tutori
 parser.add_argument('--face_cascade', help='Path to face cascade.', default='data/haarcascades/haarcascade_frontalface_alt.xml')
 parser.add_argument('--eyes_cascade', help='Path to eyes cascade.', default='data/haarcascades/haarcascade_eye_tree_eyeglasses.xml')
 parser.add_argument('--mouth_cascade', help='Path to mouth cascade.', default='data/haarcascades/haarcascade_mcs_mouth.xml')
+parser.add_argument('--nose_cascade', help='Path to nose cascade.', default='data/haarcascades/Nariz.xml')
 parser.add_argument('--camera', help='Camera divide number.', type=int, default=0)
+
 args = parser.parse_args()
 face_cascade_name = args.face_cascade
 eyes_cascade_name = args.eyes_cascade
 mouth_cascade_name = args.mouth_cascade
+nose_cascade_name = args.nose_cascade
 face_cascade = cv.CascadeClassifier()
 eyes_cascade = cv.CascadeClassifier()
 mouth_cascade = cv.CascadeClassifier()
+nose_cascade = cv.CascadeClassifier()
+
 #-- 1. Load the cascades
 if not face_cascade.load(cv.samples.findFile(face_cascade_name)): # pylint: disable=maybe-no-member
     print('--(!)Error loading face cascade')
@@ -45,6 +55,10 @@ if not eyes_cascade.load(cv.samples.findFile(eyes_cascade_name)): # pylint: disa
 if not mouth_cascade.load(cv.samples.findFile(mouth_cascade_name)): # pylint: disable=maybe-no-member
     print('--(!)Error loading eyes cascade')
     exit(0)
+if not nose_cascade.load(cv.samples.findFile(nose_cascade_name)): # pylint: disable=maybe-no-member
+    print('--(!)Error loading eyes cascade')
+    exit(0)
+
 camera_device = args.camera
 #-- 2. Read the video stream
 cap = cv.VideoCapture(camera_device, cv.CAP_DSHOW)

--- a/cascade/data/haarcascades/Nariz.xml
+++ b/cascade/data/haarcascades/Nariz.xml
@@ -1,0 +1,8953 @@
+<?xml version="1.0"?>
+<!----------------------------------------------------------------------------
+  25x15 Nose detector computed with 7000 positive samples
+
+//////////////////////////////////////////////////////////////////////////
+| Contributors License Agreement
+| IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+|   By downloading, copying, installing or using the software you agree 
+|   to this license.
+|   If you do not agree to this license, do not download, install,
+|   copy or use the software.
+|
+| Copyright (c) 2006, Modesto Castrillon-Santana (IUSIANI, University of
+| Las Palmas de Gran Canaria, Spain).
+|  All rights reserved.
+|
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions are
+| met:
+|
+|    * Redistributions of source code must retain the above copyright
+|       notice, this list of conditions and the following disclaimer.
+|    * Redistributions in binary form must reproduce the above
+|      copyright notice, this list of conditions and the following
+|      disclaimer in the documentation and/or other materials provided
+|      with the distribution.  
+|    * The name of Contributor may not used to endorse or promote products 
+|      derived from this software without specific prior written permission.
+|
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+| "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+| LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+| A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+| CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+| EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+| PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+| PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+| LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+| NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+| SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  Back to
+| Top
+//////////////////////////////////////////////////////////////////////////
+
+RESEARCH USE:
+If you are using any of the detectors or involved ideas please cite one of these papers:
+
+@ARTICLE{Castrillon07-jvci,
+  author =       "Castrill\'on Santana, M. and D\'eniz Su\'arez, O. and Hern\'andez Tejera, M. and Guerra Artal, C.",
+  title =        "ENCARA2: Real-time Detection of Multiple Faces at Different Resolutions in Video Streams",
+  journal =      "Journal of Visual Communication and Image Representation",
+  year =         "2007",
+  vol =          "18",
+  issue =        "2",
+  month =        "April",
+  pages =        "130-140"
+}
+
+@INPROCEEDINGS{Castrillon07-swb,
+  author =       "Castrill\'on Santana, M. and D\'eniz Su\'arez, O. and Hern\'andez Sosa, D. and Lorenzo Navarro, J. ",
+  title =        "Using Incremental Principal Component Analysis to Learn a Gender Classifier Automatically",
+  booktitle =    "1st Spanish Workshop on Biometrics",
+  year =         "2007",
+  month =        "June",
+  address =      "Girona, Spain",
+  file = F
+}
+
+A comparison of this and other face related classifiers can be found in:
+
+@InProceedings{Castrillon08a-visapp,
+ 'athor =       "Modesto Castrill\'on-Santana and O. D\'eniz-Su\'arez, L. Ant\'on-Canal\'{\i}s and J. Lorenzo-Navarro",
+  title =        "Face and Facial Feature Detection Evaluation"
+  booktitle =    "Third International Conference on Computer Vision Theory and Applications, VISAPP08"
+  year =         "2008",
+  month =        "January"
+}
+
+More information can be found at http://mozart.dis.ulpgc.es/Gias/modesto_eng.html or in the papers.
+
+COMMERCIAL USE:
+If you have any commercial interest in this work please contact 
+mcastrillon@iusiani.ulpgc.es
+------------------------------------------------------------------------>
+<opencv_storage>
+<Nariz_15stages type_id="opencv-haar-classifier">
+  <size>
+    25 15</size>
+  <stages>
+    <_>
+      <!-- stage 0 -->
+      <trees>
+        <_>
+          <!-- tree 0 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 3 4 6 -1.</_>
+                <_>
+                  12 3 4 3 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0586711503565311</threshold>
+            <left_val>-0.6490315794944763</left_val>
+            <right_val>0.7077465057373047</right_val></_></_>
+        <_>
+          <!-- tree 1 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  16 0 1 12 -1.</_>
+                <_>
+                  12 4 1 4 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-0.0181572195142508</threshold>
+            <left_val>0.1306011974811554</left_val>
+            <right_val>-0.0432788804173470</right_val></_></_>
+        <_>
+          <!-- tree 2 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  9 0 12 1 -1.</_>
+                <_>
+                  13 4 4 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0233568102121353</threshold>
+            <left_val>-0.5260977745056152</left_val>
+            <right_val>0.4903163015842438</right_val></_></_>
+        <_>
+          <!-- tree 3 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 6 15 9 -1.</_>
+                <_>
+                  5 9 15 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.1258783936500549</threshold>
+            <left_val>0.5870655775070190</left_val>
+            <right_val>-0.3007133901119232</right_val></_></_>
+        <_>
+          <!-- tree 4 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 4 3 1 -1.</_>
+                <_>
+                  12 4 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.4224239857867360e-003</threshold>
+            <left_val>0.1480526030063629</left_val>
+            <right_val>-0.9664418101310730</right_val></_></_>
+        <_>
+          <!-- tree 5 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 4 3 1 -1.</_>
+                <_>
+                  12 4 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-9.1703771613538265e-004</threshold>
+            <left_val>-0.8869872093200684</left_val>
+            <right_val>0.1569125056266785</right_val></_></_>
+        <_>
+          <!-- tree 6 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 0 2 1 -1.</_>
+                <_>
+                  11 0 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.1866240786039270e-005</threshold>
+            <left_val>-0.4021002054214478</left_val>
+            <right_val>0.3862163126468658</right_val></_></_>
+        <_>
+          <!-- tree 7 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 11 3 4 -1.</_>
+                <_>
+                  23 11 1 4 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.2416249159723520e-003</threshold>
+            <left_val>-0.9046580791473389</left_val>
+            <right_val>0.1055769026279450</right_val></_></_>
+        <_>
+          <!-- tree 8 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 0 16 2 -1.</_>
+                <_>
+                  8 0 8 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0113867204636335</threshold>
+            <left_val>-0.2994585931301117</left_val>
+            <right_val>0.3716689050197601</right_val></_></_>
+        <_>
+          <!-- tree 9 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 0 16 7 -1.</_>
+                <_>
+                  11 0 8 7 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0350994803011417</threshold>
+            <left_val>-0.2715699076652527</left_val>
+            <right_val>0.2379402965307236</right_val></_></_>
+        <_>
+          <!-- tree 10 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 0 2 1 -1.</_>
+                <_>
+                  11 0 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.1417581087443978e-005</threshold>
+            <left_val>0.4850082993507385</left_val>
+            <right_val>-0.2893033921718597</right_val></_></_></trees>
+      <stage_threshold>-1.5966999530792236</stage_threshold>
+      <parent>-1</parent>
+      <next>-1</next></_>
+    <_>
+      <!-- stage 1 -->
+      <trees>
+        <_>
+          <!-- tree 0 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 6 9 6 -1.</_>
+                <_>
+                  8 9 9 3 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0664049983024597</threshold>
+            <left_val>0.6551192998886108</left_val>
+            <right_val>-0.5618174076080322</right_val></_></_>
+        <_>
+          <!-- tree 1 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 0 15 12 -1.</_>
+                <_>
+                  15 0 5 12 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.1150133013725281</threshold>
+            <left_val>-0.1183302029967308</left_val>
+            <right_val>0.3708764016628265</right_val></_></_>
+        <_>
+          <!-- tree 2 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 0 15 12 -1.</_>
+                <_>
+                  5 0 5 12 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0998963713645935</threshold>
+            <left_val>0.4516583085060120</left_val>
+            <right_val>-0.3944658041000366</right_val></_></_>
+        <_>
+          <!-- tree 3 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 2 1 10 -1.</_>
+                <_>
+                  13 2 1 5 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>8.5206236690282822e-005</threshold>
+            <left_val>-0.3235344886779785</left_val>
+            <right_val>0.1206137016415596</right_val></_></_>
+        <_>
+          <!-- tree 4 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 1 3 1 -1.</_>
+                <_>
+                  12 1 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-6.3455611234530807e-004</threshold>
+            <left_val>-0.8298007249832153</left_val>
+            <right_val>0.2250156998634338</right_val></_></_>
+        <_>
+          <!-- tree 5 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 1 3 1 -1.</_>
+                <_>
+                  12 1 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.0752020170912147e-003</threshold>
+            <left_val>0.1580708026885986</left_val>
+            <right_val>-0.8543763160705566</right_val></_></_>
+        <_>
+          <!-- tree 6 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 5 15 9 -1.</_>
+                <_>
+                  5 8 15 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.1426375955343247</threshold>
+            <left_val>0.5649880766868591</left_val>
+            <right_val>-0.2808611989021301</right_val></_></_>
+        <_>
+          <!-- tree 7 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 7 3 7 -1.</_>
+                <_>
+                  12 7 1 7 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.0649169348180294e-003</threshold>
+            <left_val>-0.8239476084709168</left_val>
+            <right_val>0.1584326028823853</right_val></_></_>
+        <_>
+          <!-- tree 8 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 8 3 6 -1.</_>
+                <_>
+                  12 8 1 6 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>5.9380112215876579e-003</threshold>
+            <left_val>0.0939135774970055</left_val>
+            <right_val>-0.9550017118453980</right_val></_></_></trees>
+      <stage_threshold>-1.2463680505752563</stage_threshold>
+      <parent>0</parent>
+      <next>-1</next></_>
+    <_>
+      <!-- stage 2 -->
+      <trees>
+        <_>
+          <!-- tree 0 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 2 6 6 -1.</_>
+                <_>
+                  12 2 6 3 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0939749181270599</threshold>
+            <left_val>-0.5528973937034607</left_val>
+            <right_val>0.5527852773666382</right_val></_></_>
+        <_>
+          <!-- tree 1 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 0 4 9 -1.</_>
+                <_>
+                  10 3 4 3 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.3149605095386505</threshold>
+            <left_val>2.6520589017309248e-004</left_val>
+            <right_val>-30.3754806518554690</right_val></_></_>
+        <_>
+          <!-- tree 2 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 0 9 4 -1.</_>
+                <_>
+                  15 3 3 4 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0497258901596069</threshold>
+            <left_val>-0.4900701940059662</left_val>
+            <right_val>0.3966841995716095</right_val></_></_>
+        <_>
+          <!-- tree 3 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 0 3 3 -1.</_>
+                <_>
+                  23 0 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.9164789700880647e-003</threshold>
+            <left_val>-0.7822849750518799</left_val>
+            <right_val>0.1122988983988762</right_val></_></_>
+        <_>
+          <!-- tree 4 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 0 3 3 -1.</_>
+                <_>
+                  1 0 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.3722670264542103e-003</threshold>
+            <left_val>-0.7435042858123779</left_val>
+            <right_val>0.1410374045372009</right_val></_></_>
+        <_>
+          <!-- tree 5 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 1 3 1 -1.</_>
+                <_>
+                  23 1 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>6.2583008548244834e-004</threshold>
+            <left_val>0.1418271064758301</left_val>
+            <right_val>-0.6804944872856140</right_val></_></_>
+        <_>
+          <!-- tree 6 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 0 15 4 -1.</_>
+                <_>
+                  10 0 5 4 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0302516203373671</threshold>
+            <left_val>-0.3320431113243103</left_val>
+            <right_val>0.3074676096439362</right_val></_></_>
+        <_>
+          <!-- tree 7 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 0 3 2 -1.</_>
+                <_>
+                  23 0 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.2209710441529751e-003</threshold>
+            <left_val>0.0555219985544682</left_val>
+            <right_val>-0.7651306986808777</right_val></_></_>
+        <_>
+          <!-- tree 8 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 0 3 2 -1.</_>
+                <_>
+                  1 0 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.1841589584946632e-003</threshold>
+            <left_val>0.1364399045705795</left_val>
+            <right_val>-0.7314906716346741</right_val></_></_>
+        <_>
+          <!-- tree 9 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 9 10 5 -1.</_>
+                <_>
+                  15 9 5 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0194617491215467</threshold>
+            <left_val>0.1125520989298821</left_val>
+            <right_val>-0.1127832010388374</right_val></_></_>
+        <_>
+          <!-- tree 10 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 9 10 5 -1.</_>
+                <_>
+                  5 9 5 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0112553201615810</threshold>
+            <left_val>0.2960414886474609</left_val>
+            <right_val>-0.3298177123069763</right_val></_></_>
+        <_>
+          <!-- tree 11 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  14 0 3 1 -1.</_>
+                <_>
+                  15 1 1 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-3.2229919452220201e-003</threshold>
+            <left_val>-0.5415470004081726</left_val>
+            <right_val>0.0398343615233898</right_val></_></_>
+        <_>
+          <!-- tree 12 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  1 0 16 5 -1.</_>
+                <_>
+                  5 0 8 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0541202984750271</threshold>
+            <left_val>0.4478917121887207</left_val>
+            <right_val>-0.1791869997978210</right_val></_></_>
+        <_>
+          <!-- tree 13 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 0 4 1 -1.</_>
+                <_>
+                  16 1 2 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>6.8006571382284164e-003</threshold>
+            <left_val>0.0419190004467964</left_val>
+            <right_val>-0.8359578847885132</right_val></_></_>
+        <_>
+          <!-- tree 14 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 0 1 4 -1.</_>
+                <_>
+                  9 1 1 2 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-4.9264351837337017e-003</threshold>
+            <left_val>-0.8076645135879517</left_val>
+            <right_val>0.0878519490361214</right_val></_></_>
+        <_>
+          <!-- tree 15 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 13 3 2 -1.</_>
+                <_>
+                  19 13 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.7612510127946734e-003</threshold>
+            <left_val>0.0583671517670155</left_val>
+            <right_val>-0.7788596749305725</right_val></_></_>
+        <_>
+          <!-- tree 16 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 13 3 2 -1.</_>
+                <_>
+                  5 13 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.3990009902045131e-003</threshold>
+            <left_val>0.0804155990481377</left_val>
+            <right_val>-0.7169721722602844</right_val></_></_>
+        <_>
+          <!-- tree 17 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 10 3 5 -1.</_>
+                <_>
+                  19 10 1 5 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.8242229968309402e-003</threshold>
+            <left_val>-0.7723351716995239</left_val>
+            <right_val>0.0375796295702457</right_val></_></_></trees>
+      <stage_threshold>-1.6448220014572144</stage_threshold>
+      <parent>1</parent>
+      <next>-1</next></_>
+    <_>
+      <!-- stage 3 -->
+      <trees>
+        <_>
+          <!-- tree 0 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 4 5 4 -1.</_>
+                <_>
+                  12 4 5 2 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0403975099325180</threshold>
+            <left_val>-0.5443460941314697</left_val>
+            <right_val>0.4691714048385620</right_val></_></_>
+        <_>
+          <!-- tree 1 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 6 15 9 -1.</_>
+                <_>
+                  5 9 15 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.1257423013448715</threshold>
+            <left_val>0.4033094942569733</left_val>
+            <right_val>-0.3352571129798889</right_val></_></_>
+        <_>
+          <!-- tree 2 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 11 3 2 -1.</_>
+                <_>
+                  1 11 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.0810589883476496e-003</threshold>
+            <left_val>-0.7774288058280945</left_val>
+            <right_val>0.1340011954307556</right_val></_></_>
+        <_>
+          <!-- tree 3 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 8 2 4 -1.</_>
+                <_>
+                  22 8 1 4 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.4440169110894203e-004</threshold>
+            <left_val>0.1917365044355393</left_val>
+            <right_val>-0.2279532998800278</right_val></_></_>
+        <_>
+          <!-- tree 4 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  1 0 1 2 -1.</_>
+                <_>
+                  1 1 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0207434296607971</threshold>
+            <left_val>-5.0675910897552967e-003</left_val>
+            <right_val>-3.3646960449218750e+003</right_val></_></_>
+        <_>
+          <!-- tree 5 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 12 3 1 -1.</_>
+                <_>
+                  23 12 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-8.3800539141520858e-004</threshold>
+            <left_val>-0.6927918195724487</left_val>
+            <right_val>0.0828016772866249</right_val></_></_>
+        <_>
+          <!-- tree 6 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 0 8 1 -1.</_>
+                <_>
+                  11 0 4 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.6734489258378744e-003</threshold>
+            <left_val>-0.3244641125202179</left_val>
+            <right_val>0.3121700882911682</right_val></_></_>
+        <_>
+          <!-- tree 7 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 12 3 1 -1.</_>
+                <_>
+                  23 12 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>8.3715689834207296e-004</threshold>
+            <left_val>0.0983965769410133</left_val>
+            <right_val>-0.6591191291809082</right_val></_></_>
+        <_>
+          <!-- tree 8 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 12 3 1 -1.</_>
+                <_>
+                  1 12 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>9.3348661903291941e-004</threshold>
+            <left_val>0.1159031018614769</left_val>
+            <right_val>-0.8086990118026733</right_val></_></_>
+        <_>
+          <!-- tree 9 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 0 21 11 -1.</_>
+                <_>
+                  9 0 7 11 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.1241317987442017</threshold>
+            <left_val>-0.3207426965236664</left_val>
+            <right_val>0.2727271914482117</right_val></_></_>
+        <_>
+          <!-- tree 10 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 2 3 1 -1.</_>
+                <_>
+                  8 2 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.0077579645439982e-003</threshold>
+            <left_val>0.0869612991809845</left_val>
+            <right_val>-0.8667079806327820</right_val></_></_>
+        <_>
+          <!-- tree 11 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 9 15 4 -1.</_>
+                <_>
+                  5 11 15 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0720446631312370</threshold>
+            <left_val>0.6118348240852356</left_val>
+            <right_val>-0.1539089977741242</right_val></_></_>
+        <_>
+          <!-- tree 12 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 1 3 1 -1.</_>
+                <_>
+                  5 1 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>6.8683509016409516e-004</threshold>
+            <left_val>0.1186366006731987</left_val>
+            <right_val>-0.7158207893371582</right_val></_></_>
+        <_>
+          <!-- tree 13 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 1 3 1 -1.</_>
+                <_>
+                  19 1 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.0504099773243070e-003</threshold>
+            <left_val>0.0556956306099892</left_val>
+            <right_val>-0.7745435833930969</right_val></_></_>
+        <_>
+          <!-- tree 14 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 0 16 6 -1.</_>
+                <_>
+                  6 0 8 6 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0588022097945213</threshold>
+            <left_val>0.4719094038009644</left_val>
+            <right_val>-0.1793995946645737</right_val></_></_>
+        <_>
+          <!-- tree 15 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 3 3 1 -1.</_>
+                <_>
+                  12 3 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-6.4719992224127054e-004</threshold>
+            <left_val>-0.7908205986022949</left_val>
+            <right_val>0.0899925529956818</right_val></_></_>
+        <_>
+          <!-- tree 16 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 3 3 1 -1.</_>
+                <_>
+                  12 3 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>9.3501672381535172e-004</threshold>
+            <left_val>0.0822852626442909</left_val>
+            <right_val>-0.7588443160057068</right_val></_></_></trees>
+      <stage_threshold>-1.3605799674987793</stage_threshold>
+      <parent>2</parent>
+      <next>-1</next></_>
+    <_>
+      <!-- stage 4 -->
+      <trees>
+        <_>
+          <!-- tree 0 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 5 3 4 -1.</_>
+                <_>
+                  12 5 3 2 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0288036800920963</threshold>
+            <left_val>-0.5330266952514648</left_val>
+            <right_val>0.4628630876541138</right_val></_></_>
+        <_>
+          <!-- tree 1 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 4 18 10 -1.</_>
+                <_>
+                  15 4 9 5 2.</_>
+                <_>
+                  6 9 9 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.1718651950359345</threshold>
+            <left_val>-0.5574520826339722</left_val>
+            <right_val>0.0321308299899101</right_val></_></_>
+        <_>
+          <!-- tree 2 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 0 4 3 -1.</_>
+                <_>
+                  12 0 2 3 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>5.2562640048563480e-003</threshold>
+            <left_val>-0.2927981019020081</left_val>
+            <right_val>0.3952561914920807</right_val></_></_>
+        <_>
+          <!-- tree 3 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 2 1 10 -1.</_>
+                <_>
+                  13 2 1 5 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-0.0297412890940905</threshold>
+            <left_val>-0.6518927216529846</left_val>
+            <right_val>0.0492629408836365</right_val></_></_>
+        <_>
+          <!-- tree 4 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 11 14 1 -1.</_>
+                <_>
+                  7 11 7 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-5.2912821993231773e-003</threshold>
+            <left_val>0.3241269886493683</left_val>
+            <right_val>-0.2844972014427185</right_val></_></_>
+        <_>
+          <!-- tree 5 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 0 21 10 -1.</_>
+                <_>
+                  9 0 7 10 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.1459622979164124</threshold>
+            <left_val>-0.2975459098815918</left_val>
+            <right_val>0.2956197857856751</right_val></_></_>
+        <_>
+          <!-- tree 6 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 0 9 4 -1.</_>
+                <_>
+                  6 2 9 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0290529094636440</threshold>
+            <left_val>0.0947060883045197</left_val>
+            <right_val>-0.8066384196281433</right_val></_></_>
+        <_>
+          <!-- tree 7 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 1 1 9 -1.</_>
+                <_>
+                  10 4 1 3 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-0.0257772803306580</threshold>
+            <left_val>-0.2847819924354553</left_val>
+            <right_val>0.0312762111425400</right_val></_></_>
+        <_>
+          <!-- tree 8 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 1 9 1 -1.</_>
+                <_>
+                  15 4 3 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0153958396986127</threshold>
+            <left_val>-0.2911948859691620</left_val>
+            <right_val>0.2623308002948761</right_val></_></_>
+        <_>
+          <!-- tree 9 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 1 3 4 -1.</_>
+                <_>
+                  23 1 1 4 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-2.8286539018154144e-003</threshold>
+            <left_val>-0.6556450128555298</left_val>
+            <right_val>0.0713943019509315</right_val></_></_>
+        <_>
+          <!-- tree 10 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 1 3 4 -1.</_>
+                <_>
+                  1 1 1 4 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.3345070183277130e-003</threshold>
+            <left_val>-0.6531571745872498</left_val>
+            <right_val>0.0909745618700981</right_val></_></_>
+        <_>
+          <!-- tree 11 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 6 4 6 -1.</_>
+                <_>
+                  18 9 4 3 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0381811000406742</threshold>
+            <left_val>0.1749090999364853</left_val>
+            <right_val>-0.1175132021307945</right_val></_></_>
+        <_>
+          <!-- tree 12 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 3 2 1 -1.</_>
+                <_>
+                  1 3 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.6171150491572917e-005</threshold>
+            <left_val>0.2395249009132385</left_val>
+            <right_val>-0.2498822957277298</right_val></_></_>
+        <_>
+          <!-- tree 13 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 0 15 4 -1.</_>
+                <_>
+                  8 2 15 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0331601910293102</threshold>
+            <left_val>-0.7591074705123901</left_val>
+            <right_val>0.0791729092597961</right_val></_></_>
+        <_>
+          <!-- tree 14 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 10 15 2 -1.</_>
+                <_>
+                  5 11 15 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>9.3446429818868637e-003</threshold>
+            <left_val>-0.1579822003841400</left_val>
+            <right_val>0.4016909003257752</right_val></_></_>
+        <_>
+          <!-- tree 15 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 7 15 6 -1.</_>
+                <_>
+                  5 9 15 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0395789593458176</threshold>
+            <left_val>-0.1210685968399048</left_val>
+            <right_val>0.5701956748962402</right_val></_></_>
+        <_>
+          <!-- tree 16 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 1 3 2 -1.</_>
+                <_>
+                  1 1 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.5233360463753343e-003</threshold>
+            <left_val>0.0829860121011734</left_val>
+            <right_val>-0.7597399950027466</right_val></_></_>
+        <_>
+          <!-- tree 17 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 1 10 6 -1.</_>
+                <_>
+                  13 4 10 3 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.1084349006414414</threshold>
+            <left_val>0.0239067506045103</left_val>
+            <right_val>-0.8203359246253967</right_val></_></_>
+        <_>
+          <!-- tree 18 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  1 0 14 1 -1.</_>
+                <_>
+                  1 0 7 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-0.0329204984009266</threshold>
+            <left_val>-0.5968133807182312</left_val>
+            <right_val>0.0774828195571899</right_val></_></_>
+        <_>
+          <!-- tree 19 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 0 15 12 -1.</_>
+                <_>
+                  12 0 5 12 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0768510773777962</threshold>
+            <left_val>-0.2228861004114151</left_val>
+            <right_val>0.1625335067510605</right_val></_></_>
+        <_>
+          <!-- tree 20 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 0 12 12 -1.</_>
+                <_>
+                  8 0 4 12 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0639667585492134</threshold>
+            <left_val>-0.1191802993416786</left_val>
+            <right_val>0.4815764129161835</right_val></_></_>
+        <_>
+          <!-- tree 21 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 12 3 2 -1.</_>
+                <_>
+                  23 12 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.0903739603236318e-003</threshold>
+            <left_val>-0.5854551196098328</left_val>
+            <right_val>0.0684971734881401</right_val></_></_>
+        <_>
+          <!-- tree 22 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  3 0 16 9 -1.</_>
+                <_>
+                  7 0 8 9 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0411802418529987</threshold>
+            <left_val>0.3726958930492401</left_val>
+            <right_val>-0.1431915014982224</right_val></_></_>
+        <_>
+          <!-- tree 23 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 5 3 1 -1.</_>
+                <_>
+                  12 5 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-5.7968578767031431e-004</threshold>
+            <left_val>-0.6765481829643250</left_val>
+            <right_val>0.0794758871197701</right_val></_></_>
+        <_>
+          <!-- tree 24 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 4 3 3 -1.</_>
+                <_>
+                  12 4 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.2824629452079535e-003</threshold>
+            <left_val>0.0441441200673580</left_val>
+            <right_val>-0.7635586857795715</right_val></_></_>
+        <_>
+          <!-- tree 25 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  1 0 24 4 -1.</_>
+                <_>
+                  13 0 12 2 2.</_>
+                <_>
+                  1 2 12 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0315384306013584</threshold>
+            <left_val>-0.5541967749595642</left_val>
+            <right_val>0.0626375675201416</right_val></_></_></trees>
+      <stage_threshold>-1.4533120393753052</stage_threshold>
+      <parent>3</parent>
+      <next>-1</next></_>
+    <_>
+      <!-- stage 5 -->
+      <trees>
+        <_>
+          <!-- tree 0 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 6 15 9 -1.</_>
+                <_>
+                  5 9 15 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.1049470007419586</threshold>
+            <left_val>0.4825217127799988</left_val>
+            <right_val>-0.5042178034782410</right_val></_></_>
+        <_>
+          <!-- tree 1 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 2 4 2 -1.</_>
+                <_>
+                  12 2 2 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.8676959443837404e-003</threshold>
+            <left_val>0.1821112036705017</left_val>
+            <right_val>-0.1253813058137894</right_val></_></_>
+        <_>
+          <!-- tree 2 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 4 2 2 -1.</_>
+                <_>
+                  9 4 1 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>5.2841129217995331e-005</threshold>
+            <left_val>-0.4632568061351776</left_val>
+            <right_val>0.2032011002302170</right_val></_></_>
+        <_>
+          <!-- tree 3 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  14 2 3 5 -1.</_>
+                <_>
+                  15 2 1 5 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.3006730955094099e-003</threshold>
+            <left_val>-0.6287978291511536</left_val>
+            <right_val>0.0916443392634392</right_val></_></_>
+        <_>
+          <!-- tree 4 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 2 3 9 -1.</_>
+                <_>
+                  12 2 1 9 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.0977040549041703e-005</threshold>
+            <left_val>-0.4428875148296356</left_val>
+            <right_val>0.1480354070663452</right_val></_></_>
+        <_>
+          <!-- tree 5 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  24 0 1 14 -1.</_>
+                <_>
+                  24 0 1 7 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0321551598608494</threshold>
+            <left_val>-0.0579365491867065</left_val>
+            <right_val>0.0954785495996475</right_val></_></_>
+        <_>
+          <!-- tree 6 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 5 15 6 -1.</_>
+                <_>
+                  5 7 15 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0350527204573154</threshold>
+            <left_val>-0.2094025015830994</left_val>
+            <right_val>0.3282704055309296</right_val></_></_>
+        <_>
+          <!-- tree 7 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 2 9 4 -1.</_>
+                <_>
+                  15 2 9 2 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-0.0308129098266363</threshold>
+            <left_val>0.1500187069177628</left_val>
+            <right_val>-0.0182785093784332</right_val></_></_>
+        <_>
+          <!-- tree 8 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 5 15 8 -1.</_>
+                <_>
+                  5 7 15 4 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.1295059025287628</threshold>
+            <left_val>0.6555795073509216</left_val>
+            <right_val>-0.1312935948371887</right_val></_></_>
+        <_>
+          <!-- tree 9 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 8 4 4 -1.</_>
+                <_>
+                  15 9 4 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>5.3415680304169655e-003</threshold>
+            <left_val>-0.0502130687236786</left_val>
+            <right_val>0.3571920990943909</right_val></_></_>
+        <_>
+          <!-- tree 10 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 2 3 5 -1.</_>
+                <_>
+                  9 2 1 5 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.2626379504799843e-003</threshold>
+            <left_val>0.1152506023645401</left_val>
+            <right_val>-0.6471546888351440</right_val></_></_>
+        <_>
+          <!-- tree 11 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 13 3 2 -1.</_>
+                <_>
+                  23 13 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.6046660020947456e-003</threshold>
+            <left_val>0.0527520217001438</left_val>
+            <right_val>-0.7524214982986450</right_val></_></_>
+        <_>
+          <!-- tree 12 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 8 4 4 -1.</_>
+                <_>
+                  6 9 4 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.5375111512839794e-003</threshold>
+            <left_val>-0.1369124054908752</left_val>
+            <right_val>0.4789685904979706</right_val></_></_>
+        <_>
+          <!-- tree 13 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 13 3 2 -1.</_>
+                <_>
+                  23 13 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-9.9073955789208412e-004</threshold>
+            <left_val>-0.5942180752754211</left_val>
+            <right_val>0.0911119133234024</right_val></_></_>
+        <_>
+          <!-- tree 14 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 12 3 2 -1.</_>
+                <_>
+                  1 12 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-8.3121878560632467e-004</threshold>
+            <left_val>-0.6460539102554321</left_val>
+            <right_val>0.0765934735536575</right_val></_></_>
+        <_>
+          <!-- tree 15 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 0 15 1 -1.</_>
+                <_>
+                  10 0 5 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>6.6192341037094593e-003</threshold>
+            <left_val>-0.2471961975097656</left_val>
+            <right_val>0.2244677990674973</right_val></_></_>
+        <_>
+          <!-- tree 16 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  1 0 14 1 -1.</_>
+                <_>
+                  1 0 7 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-0.0175065398216248</threshold>
+            <left_val>-0.5839226841926575</left_val>
+            <right_val>0.1092939004302025</right_val></_></_>
+        <_>
+          <!-- tree 17 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 0 4 7 -1.</_>
+                <_>
+                  11 0 2 7 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0174752809107304</threshold>
+            <left_val>0.3877553045749664</left_val>
+            <right_val>-0.2122619003057480</right_val></_></_>
+        <_>
+          <!-- tree 18 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 0 8 6 -1.</_>
+                <_>
+                  6 3 8 3 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0215590093284845</threshold>
+            <left_val>-0.5536571741104126</left_val>
+            <right_val>0.1239048987627029</right_val></_></_>
+        <_>
+          <!-- tree 19 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 1 3 3 -1.</_>
+                <_>
+                  23 1 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.0007239654660225e-003</threshold>
+            <left_val>0.0400657504796982</left_val>
+            <right_val>-0.6749160885810852</right_val></_></_>
+        <_>
+          <!-- tree 20 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 10 3 3 -1.</_>
+                <_>
+                  7 11 3 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.1444390770047903e-003</threshold>
+            <left_val>-0.1262197941541672</left_val>
+            <right_val>0.4580610990524292</right_val></_></_>
+        <_>
+          <!-- tree 21 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 12 3 3 -1.</_>
+                <_>
+                  23 12 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.2618169421330094e-003</threshold>
+            <left_val>0.0594217516481876</left_val>
+            <right_val>-0.2875005900859833</right_val></_></_>
+        <_>
+          <!-- tree 22 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 12 3 3 -1.</_>
+                <_>
+                  1 12 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.6001570038497448e-003</threshold>
+            <left_val>0.0821361988782883</left_val>
+            <right_val>-0.6180136203765869</right_val></_></_>
+        <_>
+          <!-- tree 23 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  17 9 8 6 -1.</_>
+                <_>
+                  17 9 4 6 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0127480402588844</threshold>
+            <left_val>0.2064097970724106</left_val>
+            <right_val>-0.1948879063129425</right_val></_></_>
+        <_>
+          <!-- tree 24 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 1 3 3 -1.</_>
+                <_>
+                  1 1 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.5863180160522461e-003</threshold>
+            <left_val>-0.7417026758193970</left_val>
+            <right_val>0.0625618472695351</right_val></_></_>
+        <_>
+          <!-- tree 25 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  17 9 8 6 -1.</_>
+                <_>
+                  17 9 4 6 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.1212091967463493</threshold>
+            <left_val>-0.5923119783401489</left_val>
+            <right_val>-4.3050181120634079e-003</right_val></_></_>
+        <_>
+          <!-- tree 26 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 9 8 6 -1.</_>
+                <_>
+                  4 9 4 6 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-9.5990803092718124e-003</threshold>
+            <left_val>0.2008689939975739</left_val>
+            <right_val>-0.2386385947465897</right_val></_></_>
+        <_>
+          <!-- tree 27 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 11 3 3 -1.</_>
+                <_>
+                  12 11 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.9258679822087288e-003</threshold>
+            <left_val>-0.7000058889389038</left_val>
+            <right_val>0.0608637109398842</right_val></_></_></trees>
+      <stage_threshold>-1.3771890401840210</stage_threshold>
+      <parent>4</parent>
+      <next>-1</next></_>
+    <_>
+      <!-- stage 6 -->
+      <trees>
+        <_>
+          <!-- tree 0 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 11 15 2 -1.</_>
+                <_>
+                  5 12 15 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.0494929999113083e-003</threshold>
+            <left_val>-0.3507097959518433</left_val>
+            <right_val>0.4280264079570770</right_val></_></_>
+        <_>
+          <!-- tree 1 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 0 4 1 -1.</_>
+                <_>
+                  12 0 2 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.5838489634916186e-003</threshold>
+            <left_val>0.1951383948326111</left_val>
+            <right_val>-0.0965218916535378</right_val></_></_>
+        <_>
+          <!-- tree 2 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 8 9 2 -1.</_>
+                <_>
+                  8 9 9 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-7.0312782190740108e-003</threshold>
+            <left_val>0.2624438107013702</left_val>
+            <right_val>-0.4274739027023315</right_val></_></_>
+        <_>
+          <!-- tree 3 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 0 12 5 -1.</_>
+                <_>
+                  16 0 6 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0289421398192644</threshold>
+            <left_val>0.3861246109008789</left_val>
+            <right_val>-0.1477382928133011</right_val></_></_>
+        <_>
+          <!-- tree 4 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  9 0 4 1 -1.</_>
+                <_>
+                  11 0 2 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>6.7051762016490102e-004</threshold>
+            <left_val>-0.3925149142742157</left_val>
+            <right_val>0.3037196099758148</right_val></_></_>
+        <_>
+          <!-- tree 5 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 8 2 7 -1.</_>
+                <_>
+                  18 8 1 7 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>8.5873872740194201e-004</threshold>
+            <left_val>-0.1103229969739914</left_val>
+            <right_val>0.1238769963383675</right_val></_></_>
+        <_>
+          <!-- tree 6 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 8 2 7 -1.</_>
+                <_>
+                  6 8 1 7 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.0908590047620237e-004</threshold>
+            <left_val>0.2161597013473511</left_val>
+            <right_val>-0.3508378863334656</right_val></_></_>
+        <_>
+          <!-- tree 7 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  1 0 24 8 -1.</_>
+                <_>
+                  13 0 12 4 2.</_>
+                <_>
+                  1 4 12 4 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0964791998267174</threshold>
+            <left_val>0.1354860961437225</left_val>
+            <right_val>-0.7859892845153809</right_val></_></_>
+        <_>
+          <!-- tree 8 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 6 3 1 -1.</_>
+                <_>
+                  12 6 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.9438572023063898e-004</threshold>
+            <left_val>-0.7013131976127625</left_val>
+            <right_val>0.0424073003232479</right_val></_></_>
+        <_>
+          <!-- tree 9 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  23 2 2 1 -1.</_>
+                <_>
+                  23 2 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.6171150491572917e-005</threshold>
+            <left_val>0.1750625967979431</left_val>
+            <right_val>-0.1454585045576096</right_val></_></_>
+        <_>
+          <!-- tree 10 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 0 2 7 -1.</_>
+                <_>
+                  1 0 1 7 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.6641140215797350e-005</threshold>
+            <left_val>0.1956603974103928</left_val>
+            <right_val>-0.2611208856105804</right_val></_></_>
+        <_>
+          <!-- tree 11 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  17 1 8 14 -1.</_>
+                <_>
+                  17 8 8 7 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0296642407774925</threshold>
+            <left_val>0.1609143018722534</left_val>
+            <right_val>-0.3350951969623566</right_val></_></_>
+        <_>
+          <!-- tree 12 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 9 15 4 -1.</_>
+                <_>
+                  5 10 15 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>9.2956535518169403e-003</threshold>
+            <left_val>-0.1104964017868042</left_val>
+            <right_val>0.4806717038154602</right_val></_></_>
+        <_>
+          <!-- tree 13 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 13 3 2 -1.</_>
+                <_>
+                  19 13 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.6447249799966812e-003</threshold>
+            <left_val>-0.6849219799041748</left_val>
+            <right_val>0.0722444504499435</right_val></_></_>
+        <_>
+          <!-- tree 14 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 8 4 3 -1.</_>
+                <_>
+                  7 9 4 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.1482249032706022e-003</threshold>
+            <left_val>-0.1469774991273880</left_val>
+            <right_val>0.3923855125904083</right_val></_></_>
+        <_>
+          <!-- tree 15 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 11 3 4 -1.</_>
+                <_>
+                  19 11 1 4 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.8073729481548071e-003</threshold>
+            <left_val>0.0678852573037148</left_val>
+            <right_val>-0.7827072143554688</right_val></_></_>
+        <_>
+          <!-- tree 16 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 7 15 2 -1.</_>
+                <_>
+                  5 8 15 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0142753198742867</threshold>
+            <left_val>0.2063581943511963</left_val>
+            <right_val>-0.2316451966762543</right_val></_></_>
+        <_>
+          <!-- tree 17 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  19 0 6 14 -1.</_>
+                <_>
+                  19 7 6 7 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.2049915939569473</threshold>
+            <left_val>-0.4582655131816864</left_val>
+            <right_val>0.0568326599895954</right_val></_></_>
+        <_>
+          <!-- tree 18 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 0 4 2 -1.</_>
+                <_>
+                  10 0 4 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-5.9277098625898361e-003</threshold>
+            <left_val>-0.6572002172470093</left_val>
+            <right_val>0.0721553564071655</right_val></_></_>
+        <_>
+          <!-- tree 19 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 12 3 3 -1.</_>
+                <_>
+                  19 12 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.1714268736541271e-003</threshold>
+            <left_val>-0.6682463884353638</left_val>
+            <right_val>4.1404590592719615e-004</right_val></_></_>
+        <_>
+          <!-- tree 20 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 12 3 3 -1.</_>
+                <_>
+                  5 12 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.1051981020718813e-003</threshold>
+            <left_val>0.0603015385568142</left_val>
+            <right_val>-0.7591109275817871</right_val></_></_>
+        <_>
+          <!-- tree 21 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 2 3 1 -1.</_>
+                <_>
+                  12 2 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.2156879529356956e-003</threshold>
+            <left_val>0.0400662086904049</left_val>
+            <right_val>-0.8118994832038879</right_val></_></_>
+        <_>
+          <!-- tree 22 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 0 7 14 -1.</_>
+                <_>
+                  0 7 7 7 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.2109705060720444</threshold>
+            <left_val>-0.6288774013519287</left_val>
+            <right_val>0.0601908005774021</right_val></_></_>
+        <_>
+          <!-- tree 23 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 13 3 2 -1.</_>
+                <_>
+                  19 13 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.8683590460568666e-003</threshold>
+            <left_val>0.0111050596460700</left_val>
+            <right_val>-0.5660418868064880</right_val></_></_>
+        <_>
+          <!-- tree 24 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 1 8 14 -1.</_>
+                <_>
+                  0 8 8 7 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0944372937083244</threshold>
+            <left_val>0.0746664404869080</left_val>
+            <right_val>-0.5679780244827271</right_val></_></_>
+        <_>
+          <!-- tree 25 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 13 11 2 -1.</_>
+                <_>
+                  7 14 11 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.8829429754987359e-003</threshold>
+            <left_val>-0.2125732004642487</left_val>
+            <right_val>0.2099888026714325</right_val></_></_>
+        <_>
+          <!-- tree 26 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 5 2 1 -1.</_>
+                <_>
+                  8 5 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.7596050383872353e-005</threshold>
+            <left_val>-0.2497144937515259</left_val>
+            <right_val>0.1735198944807053</right_val></_></_>
+        <_>
+          <!-- tree 27 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 13 3 2 -1.</_>
+                <_>
+                  19 13 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.5754219172522426e-005</threshold>
+            <left_val>0.0591984391212463</left_val>
+            <right_val>-0.0572729408740997</right_val></_></_>
+        <_>
+          <!-- tree 28 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 13 3 2 -1.</_>
+                <_>
+                  5 13 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-2.1126060746610165e-003</threshold>
+            <left_val>-0.7910094857215881</left_val>
+            <right_val>0.0497858002781868</right_val></_></_>
+        <_>
+          <!-- tree 29 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 11 15 4 -1.</_>
+                <_>
+                  5 12 15 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0135337999090552</threshold>
+            <left_val>-0.1247676014900208</left_val>
+            <right_val>0.3491724133491516</right_val></_></_>
+        <_>
+          <!-- tree 30 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 10 3 2 -1.</_>
+                <_>
+                  11 11 3 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-2.6407879777252674e-003</threshold>
+            <left_val>0.2789241075515747</left_val>
+            <right_val>-0.1535502970218658</right_val></_></_>
+        <_>
+          <!-- tree 31 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 1 3 12 -1.</_>
+                <_>
+                  23 1 1 12 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>5.3730388171970844e-003</threshold>
+            <left_val>0.0492615103721619</left_val>
+            <right_val>-0.6450436115264893</right_val></_></_>
+        <_>
+          <!-- tree 32 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 1 3 12 -1.</_>
+                <_>
+                  1 1 1 12 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.5101480316370726e-003</threshold>
+            <left_val>-0.6527525782585144</left_val>
+            <right_val>0.0538621395826340</right_val></_></_></trees>
+      <stage_threshold>-1.4674810171127319</stage_threshold>
+      <parent>5</parent>
+      <next>-1</next></_>
+    <_>
+      <!-- stage 7 -->
+      <trees>
+        <_>
+          <!-- tree 0 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 6 15 9 -1.</_>
+                <_>
+                  5 9 15 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.1777630001306534</threshold>
+            <left_val>0.4390595853328705</left_val>
+            <right_val>-0.3043788075447083</right_val></_></_>
+        <_>
+          <!-- tree 1 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 0 8 13 -1.</_>
+                <_>
+                  15 0 4 13 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0260067004710436</threshold>
+            <left_val>-0.1197787970304489</left_val>
+            <right_val>0.3030242919921875</right_val></_></_>
+        <_>
+          <!-- tree 2 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 0 8 13 -1.</_>
+                <_>
+                  6 0 4 13 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0176265407353640</threshold>
+            <left_val>0.2795472145080566</left_val>
+            <right_val>-0.3519586920738220</right_val></_></_>
+        <_>
+          <!-- tree 3 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 0 3 3 -1.</_>
+                <_>
+                  12 0 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.6421221011551097e-005</threshold>
+            <left_val>-0.3404164910316467</left_val>
+            <right_val>0.2060022056102753</right_val></_></_>
+        <_>
+          <!-- tree 4 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 2 3 9 -1.</_>
+                <_>
+                  9 5 1 3 9.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>6.9257649593055248e-003</threshold>
+            <left_val>-0.2716875970363617</left_val>
+            <right_val>0.2117625027894974</right_val></_></_>
+        <_>
+          <!-- tree 5 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 8 4 6 -1.</_>
+                <_>
+                  15 10 4 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0101877702400088</threshold>
+            <left_val>0.0827283263206482</left_val>
+            <right_val>-0.1113948002457619</right_val></_></_>
+        <_>
+          <!-- tree 6 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 8 4 6 -1.</_>
+                <_>
+                  6 10 4 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0109565500169992</threshold>
+            <left_val>-0.1103437989950180</left_val>
+            <right_val>0.4852459132671356</right_val></_></_>
+        <_>
+          <!-- tree 7 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 0 6 1 -1.</_>
+                <_>
+                  13 0 3 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>4.6498537994921207e-003</threshold>
+            <left_val>-0.0652244836091995</left_val>
+            <right_val>0.1531576961278915</right_val></_></_>
+        <_>
+          <!-- tree 8 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 4 2 1 -1.</_>
+                <_>
+                  1 4 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.4896649594884366e-005</threshold>
+            <left_val>0.2015586942434311</left_val>
+            <right_val>-0.2269559055566788</right_val></_></_>
+        <_>
+          <!-- tree 9 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 0 13 4 -1.</_>
+                <_>
+                  10 2 13 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0261915791779757</threshold>
+            <left_val>-0.7230287790298462</left_val>
+            <right_val>0.0623125210404396</right_val></_></_>
+        <_>
+          <!-- tree 10 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  1 0 22 4 -1.</_>
+                <_>
+                  1 0 11 2 2.</_>
+                <_>
+                  12 2 11 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0374376885592937</threshold>
+            <left_val>0.0557997301220894</left_val>
+            <right_val>-0.7034118771553040</right_val></_></_>
+        <_>
+          <!-- tree 11 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 0 8 8 -1.</_>
+                <_>
+                  13 4 8 4 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.1482674032449722</threshold>
+            <left_val>9.0787047520279884e-003</left_val>
+            <right_val>-0.7327268123626709</right_val></_></_>
+        <_>
+          <!-- tree 12 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 4 20 10 -1.</_>
+                <_>
+                  0 4 10 5 2.</_>
+                <_>
+                  10 9 10 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0161518491804600</threshold>
+            <left_val>0.1065163984894753</left_val>
+            <right_val>-0.3899255990982056</right_val></_></_>
+        <_>
+          <!-- tree 13 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 0 6 2 -1.</_>
+                <_>
+                  10 1 6 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>6.7160730250179768e-003</threshold>
+            <left_val>0.0591733008623123</left_val>
+            <right_val>-0.6874551773071289</right_val></_></_>
+        <_>
+          <!-- tree 14 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 1 1 14 -1.</_>
+                <_>
+                  2 8 1 7 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0178298894315958</threshold>
+            <left_val>0.0421058908104897</left_val>
+            <right_val>-0.6671432852745056</right_val></_></_>
+        <_>
+          <!-- tree 15 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 12 3 1 -1.</_>
+                <_>
+                  23 12 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-5.0465541426092386e-004</threshold>
+            <left_val>-0.3605192899703980</left_val>
+            <right_val>0.0377061106264591</right_val></_></_>
+        <_>
+          <!-- tree 16 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 3 2 2 -1.</_>
+                <_>
+                  12 3 1 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.3641531374305487e-004</threshold>
+            <left_val>-0.2224889993667603</left_val>
+            <right_val>0.1631053984165192</right_val></_></_>
+        <_>
+          <!-- tree 17 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 4 3 1 -1.</_>
+                <_>
+                  12 4 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>9.5389381749555469e-004</threshold>
+            <left_val>0.0685663372278214</left_val>
+            <right_val>-0.6627296209335327</right_val></_></_>
+        <_>
+          <!-- tree 18 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 7 1 3 -1.</_>
+                <_>
+                  7 8 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>5.7026202557608485e-004</threshold>
+            <left_val>-0.1525606065988541</left_val>
+            <right_val>0.2640227973461151</right_val></_></_>
+        <_>
+          <!-- tree 19 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 5 15 4 -1.</_>
+                <_>
+                  5 7 15 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0762343034148216</threshold>
+            <left_val>0.3797006905078888</left_val>
+            <right_val>-0.1051399037241936</right_val></_></_>
+        <_>
+          <!-- tree 20 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 8 6 3 -1.</_>
+                <_>
+                  6 9 6 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.1566621512174606e-003</threshold>
+            <left_val>-0.1059489995241165</left_val>
+            <right_val>0.3524923026561737</right_val></_></_>
+        <_>
+          <!-- tree 21 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 8 3 1 -1.</_>
+                <_>
+                  12 8 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.6957831364125013e-004</threshold>
+            <left_val>-0.5378490090370178</left_val>
+            <right_val>0.0734837874770164</right_val></_></_>
+        <_>
+          <!-- tree 22 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 12 3 3 -1.</_>
+                <_>
+                  1 12 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-9.5949089154601097e-004</threshold>
+            <left_val>-0.4906913042068481</left_val>
+            <right_val>0.0609659403562546</right_val></_></_>
+        <_>
+          <!-- tree 23 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 12 10 2 -1.</_>
+                <_>
+                  20 12 5 1 2.</_>
+                <_>
+                  15 13 5 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.2566040754318237e-003</threshold>
+            <left_val>-0.0929865092039108</left_val>
+            <right_val>0.1980379968881607</right_val></_></_>
+        <_>
+          <!-- tree 24 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 10 3 5 -1.</_>
+                <_>
+                  1 10 1 5 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.1747780740261078e-003</threshold>
+            <left_val>0.0508758500218391</left_val>
+            <right_val>-0.6813253164291382</right_val></_></_>
+        <_>
+          <!-- tree 25 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  9 9 16 4 -1.</_>
+                <_>
+                  13 9 8 4 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0246218908578157</threshold>
+            <left_val>0.0768596604466438</left_val>
+            <right_val>-0.0480555817484856</right_val></_></_>
+        <_>
+          <!-- tree 26 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  9 9 6 2 -1.</_>
+                <_>
+                  12 9 3 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.5230941139161587e-003</threshold>
+            <left_val>-0.2049534022808075</left_val>
+            <right_val>0.2070470005273819</right_val></_></_>
+        <_>
+          <!-- tree 27 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 0 14 15 -1.</_>
+                <_>
+                  6 0 7 15 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.2623428106307983</threshold>
+            <left_val>-0.0804454237222672</left_val>
+            <right_val>0.6508840918540955</right_val></_></_>
+        <_>
+          <!-- tree 28 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 10 15 3 -1.</_>
+                <_>
+                  5 11 15 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0102441199123859</threshold>
+            <left_val>-0.0744299665093422</left_val>
+            <right_val>0.4305082857608795</right_val></_></_>
+        <_>
+          <!-- tree 29 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 12 10 2 -1.</_>
+                <_>
+                  20 12 5 1 2.</_>
+                <_>
+                  15 13 5 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.3583349324762821e-003</threshold>
+            <left_val>0.3101500868797302</left_val>
+            <right_val>-0.0724568217992783</right_val></_></_>
+        <_>
+          <!-- tree 30 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 11 8 4 -1.</_>
+                <_>
+                  0 11 4 2 2.</_>
+                <_>
+                  4 13 4 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.5561898946762085e-003</threshold>
+            <left_val>-0.1962133049964905</left_val>
+            <right_val>0.1995197981595993</right_val></_></_>
+        <_>
+          <!-- tree 31 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 0 3 7 -1.</_>
+                <_>
+                  19 0 1 7 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-7.7495030127465725e-003</threshold>
+            <left_val>-0.6803321838378906</left_val>
+            <right_val>0.0217144303023815</right_val></_></_>
+        <_>
+          <!-- tree 32 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 0 3 7 -1.</_>
+                <_>
+                  5 0 1 7 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.8965858295559883e-003</threshold>
+            <left_val>0.0367642194032669</left_val>
+            <right_val>-0.8568807244300842</right_val></_></_>
+        <_>
+          <!-- tree 33 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 0 8 12 -1.</_>
+                <_>
+                  12 0 4 12 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0304133705794811</threshold>
+            <left_val>-0.1520531028509140</left_val>
+            <right_val>0.1834755986928940</right_val></_></_>
+        <_>
+          <!-- tree 34 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 7 3 2 -1.</_>
+                <_>
+                  12 7 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.2582150995731354e-003</threshold>
+            <left_val>0.0572438910603523</left_val>
+            <right_val>-0.6239194273948669</right_val></_></_>
+        <_>
+          <!-- tree 35 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  17 6 1 3 -1.</_>
+                <_>
+                  17 7 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>5.3218309767544270e-004</threshold>
+            <left_val>-0.1141704991459847</left_val>
+            <right_val>0.1339292973279953</right_val></_></_>
+        <_>
+          <!-- tree 36 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 0 12 7 -1.</_>
+                <_>
+                  10 0 4 7 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0412225387990475</threshold>
+            <left_val>0.4358606040477753</left_val>
+            <right_val>-0.0764487832784653</right_val></_></_>
+        <_>
+          <!-- tree 37 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  3 0 20 3 -1.</_>
+                <_>
+                  8 0 10 3 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>5.6904521770775318e-003</threshold>
+            <left_val>-0.2743869125843048</left_val>
+            <right_val>0.1470285058021545</right_val></_></_>
+        <_>
+          <!-- tree 38 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 6 3 3 -1.</_>
+                <_>
+                  5 7 3 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.5077800489962101e-003</threshold>
+            <left_val>-0.1430207043886185</left_val>
+            <right_val>0.2464202940464020</right_val></_></_>
+        <_>
+          <!-- tree 39 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 1 3 1 -1.</_>
+                <_>
+                  23 1 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-8.8027317542582750e-004</threshold>
+            <left_val>-0.6672130227088928</left_val>
+            <right_val>0.0533698387444019</right_val></_></_>
+        <_>
+          <!-- tree 40 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 1 3 1 -1.</_>
+                <_>
+                  1 1 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-5.2335311193019152e-004</threshold>
+            <left_val>-0.5769776105880737</left_val>
+            <right_val>0.0462411902844906</right_val></_></_>
+        <_>
+          <!-- tree 41 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 7 3 4 -1.</_>
+                <_>
+                  21 7 1 4 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-2.3810779675841331e-003</threshold>
+            <left_val>0.3574335873126984</left_val>
+            <right_val>-0.1050473973155022</right_val></_></_>
+        <_>
+          <!-- tree 42 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 1 3 1 -1.</_>
+                <_>
+                  1 1 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>7.1191688766703010e-004</threshold>
+            <left_val>0.0585250481963158</left_val>
+            <right_val>-0.5768309235572815</right_val></_></_>
+        <_>
+          <!-- tree 43 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  19 1 4 3 -1.</_>
+                <_>
+                  18 2 4 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>7.1668238379061222e-003</threshold>
+            <left_val>-0.0483938194811344</left_val>
+            <right_val>0.1714977025985718</right_val></_></_>
+        <_>
+          <!-- tree 44 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 7 3 4 -1.</_>
+                <_>
+                  3 7 1 4 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-2.1147970110177994e-003</threshold>
+            <left_val>0.3731125891208649</left_val>
+            <right_val>-0.0889763832092285</right_val></_></_>
+        <_>
+          <!-- tree 45 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 5 3 7 -1.</_>
+                <_>
+                  21 5 1 7 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.3113129213452339e-003</threshold>
+            <left_val>-0.0512678883969784</left_val>
+            <right_val>0.3715907931327820</right_val></_></_></trees>
+      <stage_threshold>-1.4555330276489258</stage_threshold>
+      <parent>6</parent>
+      <next>-1</next></_>
+    <_>
+      <!-- stage 8 -->
+      <trees>
+        <_>
+          <!-- tree 0 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  9 1 4 5 -1.</_>
+                <_>
+                  11 1 2 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>5.5192201398313046e-003</threshold>
+            <left_val>-0.4638737142086029</left_val>
+            <right_val>0.3395589888095856</right_val></_></_>
+        <_>
+          <!-- tree 1 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 7 9 2 -1.</_>
+                <_>
+                  8 8 9 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-7.6785800047218800e-003</threshold>
+            <left_val>0.2607822120189667</left_val>
+            <right_val>-0.3878971934318543</right_val></_></_>
+        <_>
+          <!-- tree 2 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 1 10 2 -1.</_>
+                <_>
+                  6 1 10 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0115430597215891</threshold>
+            <left_val>-0.3228954076766968</left_val>
+            <right_val>0.2214114964008331</right_val></_></_>
+        <_>
+          <!-- tree 3 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  14 6 2 2 -1.</_>
+                <_>
+                  14 6 2 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-1.7733060522004962e-003</threshold>
+            <left_val>0.3505494892597199</left_val>
+            <right_val>-5.7726269587874413e-003</right_val></_></_>
+        <_>
+          <!-- tree 4 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 3 6 12 -1.</_>
+                <_>
+                  0 6 6 6 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0862847194075584</threshold>
+            <left_val>-0.6345738172531128</left_val>
+            <right_val>0.1109445989131928</right_val></_></_>
+        <_>
+          <!-- tree 5 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  14 0 3 12 -1.</_>
+                <_>
+                  14 0 3 6 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.2264384031295776</threshold>
+            <left_val>-0.0151578197255731</left_val>
+            <right_val>0.1666541993618012</right_val></_></_>
+        <_>
+          <!-- tree 6 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 1 9 1 -1.</_>
+                <_>
+                  15 4 3 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0158757194876671</threshold>
+            <left_val>-0.2909736037254334</left_val>
+            <right_val>0.1962431967258453</right_val></_></_>
+        <_>
+          <!-- tree 7 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  3 0 20 15 -1.</_>
+                <_>
+                  3 0 10 15 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.2694289982318878</threshold>
+            <left_val>-0.1294071972370148</left_val>
+            <right_val>0.5179364085197449</right_val></_></_>
+        <_>
+          <!-- tree 8 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  3 8 9 7 -1.</_>
+                <_>
+                  6 8 3 7 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0104205198585987</threshold>
+            <left_val>0.2177495062351227</left_val>
+            <right_val>-0.2513335943222046</right_val></_></_>
+        <_>
+          <!-- tree 9 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 2 3 1 -1.</_>
+                <_>
+                  16 2 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.2262510135769844e-003</threshold>
+            <left_val>-0.7603644728660584</left_val>
+            <right_val>0.0357098989188671</right_val></_></_>
+        <_>
+          <!-- tree 10 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 2 3 1 -1.</_>
+                <_>
+                  8 2 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.3248750474303961e-003</threshold>
+            <left_val>-0.7628486752510071</left_val>
+            <right_val>0.0638575181365013</right_val></_></_>
+        <_>
+          <!-- tree 11 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 7 15 3 -1.</_>
+                <_>
+                  5 8 15 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>5.0306511111557484e-003</threshold>
+            <left_val>-0.1857362985610962</left_val>
+            <right_val>0.2356601953506470</right_val></_></_>
+        <_>
+          <!-- tree 12 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 0 12 5 -1.</_>
+                <_>
+                  3 0 6 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0113980602473021</threshold>
+            <left_val>0.1863301992416382</left_val>
+            <right_val>-0.2419328987598419</right_val></_></_>
+        <_>
+          <!-- tree 13 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  14 0 4 2 -1.</_>
+                <_>
+                  14 0 2 2 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>6.3831098377704620e-003</threshold>
+            <left_val>-0.0642175897955894</left_val>
+            <right_val>0.1975664049386978</right_val></_></_>
+        <_>
+          <!-- tree 14 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 0 2 4 -1.</_>
+                <_>
+                  11 0 2 2 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0198837500065565</threshold>
+            <left_val>0.0869473069906235</left_val>
+            <right_val>-0.5899052023887634</right_val></_></_>
+        <_>
+          <!-- tree 15 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 0 4 9 -1.</_>
+                <_>
+                  11 0 2 9 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0206828191876411</threshold>
+            <left_val>0.3219321072101593</left_val>
+            <right_val>-0.1686266958713532</right_val></_></_>
+        <_>
+          <!-- tree 16 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 0 10 4 -1.</_>
+                <_>
+                  12 0 5 4 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.2020998001098633</threshold>
+            <left_val>-0.1080088987946510</left_val>
+            <right_val>0.4394289851188660</right_val></_></_>
+        <_>
+          <!-- tree 17 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  1 0 24 10 -1.</_>
+                <_>
+                  13 0 12 5 2.</_>
+                <_>
+                  1 5 12 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.1325393021106720</threshold>
+            <left_val>0.0983817502856255</left_val>
+            <right_val>-0.5801746845245361</right_val></_></_>
+        <_>
+          <!-- tree 18 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 0 3 6 -1.</_>
+                <_>
+                  5 0 1 6 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-6.2072682194411755e-003</threshold>
+            <left_val>-0.8776184916496277</left_val>
+            <right_val>0.0261308308690786</right_val></_></_>
+        <_>
+          <!-- tree 19 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 2 5 4 -1.</_>
+                <_>
+                  19 3 5 2 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0231270100921392</threshold>
+            <left_val>-0.0758198127150536</left_val>
+            <right_val>0.3633120954036713</right_val></_></_>
+        <_>
+          <!-- tree 20 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 2 4 5 -1.</_>
+                <_>
+                  6 3 2 5 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-0.0149237699806690</threshold>
+            <left_val>0.4429956078529358</left_val>
+            <right_val>-0.0725219473242760</right_val></_></_>
+        <_>
+          <!-- tree 21 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  19 2 5 3 -1.</_>
+                <_>
+                  18 3 5 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-7.9075209796428680e-003</threshold>
+            <left_val>0.2528443038463593</left_val>
+            <right_val>-0.0408613495528698</right_val></_></_>
+        <_>
+          <!-- tree 22 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 2 3 5 -1.</_>
+                <_>
+                  7 3 1 5 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>6.1556771397590637e-003</threshold>
+            <left_val>-0.1078035011887550</left_val>
+            <right_val>0.3353042900562286</right_val></_></_>
+        <_>
+          <!-- tree 23 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  14 0 3 1 -1.</_>
+                <_>
+                  15 1 1 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-3.8061200175434351e-003</threshold>
+            <left_val>-0.4219976067543030</left_val>
+            <right_val>0.0206543002277613</right_val></_></_>
+        <_>
+          <!-- tree 24 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 0 1 3 -1.</_>
+                <_>
+                  10 1 1 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-4.7234939411282539e-003</threshold>
+            <left_val>-0.8438392877578735</left_val>
+            <right_val>0.0402528494596481</right_val></_></_>
+        <_>
+          <!-- tree 25 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 0 5 4 -1.</_>
+                <_>
+                  10 2 5 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0158801693469286</threshold>
+            <left_val>0.0472384393215179</left_val>
+            <right_val>-0.5819016098976135</right_val></_></_>
+        <_>
+          <!-- tree 26 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 12 3 2 -1.</_>
+                <_>
+                  5 12 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.3915840536355972e-003</threshold>
+            <left_val>-0.5836936235427856</left_val>
+            <right_val>0.0478183813393116</right_val></_></_>
+        <_>
+          <!-- tree 27 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 13 3 1 -1.</_>
+                <_>
+                  19 13 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.0036330204457045e-003</threshold>
+            <left_val>0.0254221707582474</left_val>
+            <right_val>-0.6633707880973816</right_val></_></_>
+        <_>
+          <!-- tree 28 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 13 3 1 -1.</_>
+                <_>
+                  5 13 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>5.9566117124632001e-004</threshold>
+            <left_val>0.0612320117652416</left_val>
+            <right_val>-0.5352051854133606</right_val></_></_>
+        <_>
+          <!-- tree 29 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 8 3 4 -1.</_>
+                <_>
+                  21 8 1 4 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.7876529600471258e-003</threshold>
+            <left_val>0.3642694950103760</left_val>
+            <right_val>-0.1386588960886002</right_val></_></_>
+        <_>
+          <!-- tree 30 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 0 6 11 -1.</_>
+                <_>
+                  10 0 2 11 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0116667496040463</threshold>
+            <left_val>-0.1108686029911041</left_val>
+            <right_val>0.2568233907222748</right_val></_></_>
+        <_>
+          <!-- tree 31 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 6 3 9 -1.</_>
+                <_>
+                  14 6 1 9 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.2156259510666132e-003</threshold>
+            <left_val>-0.0844841077923775</left_val>
+            <right_val>0.1706469058990479</right_val></_></_>
+        <_>
+          <!-- tree 32 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 9 21 6 -1.</_>
+                <_>
+                  9 9 7 6 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.2147253006696701</threshold>
+            <left_val>0.0510362200438976</left_val>
+            <right_val>-0.6959053874015808</right_val></_></_>
+        <_>
+          <!-- tree 33 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 9 3 4 -1.</_>
+                <_>
+                  12 9 1 4 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-2.2432149853557348e-003</threshold>
+            <left_val>-0.6570060849189758</left_val>
+            <right_val>0.0390201695263386</right_val></_></_>
+        <_>
+          <!-- tree 34 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 2 3 1 -1.</_>
+                <_>
+                  1 2 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>9.7296462627127767e-004</threshold>
+            <left_val>0.0331785306334496</left_val>
+            <right_val>-0.7072870135307312</right_val></_></_>
+        <_>
+          <!-- tree 35 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  24 0 1 6 -1.</_>
+                <_>
+                  24 2 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.4509169850498438e-003</threshold>
+            <left_val>-0.1085728034377098</left_val>
+            <right_val>0.1958383023738861</right_val></_></_>
+        <_>
+          <!-- tree 36 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  9 6 4 4 -1.</_>
+                <_>
+                  8 7 4 2 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>8.4375571459531784e-003</threshold>
+            <left_val>-0.0610616505146027</left_val>
+            <right_val>0.4743489921092987</right_val></_></_>
+        <_>
+          <!-- tree 37 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 11 10 4 -1.</_>
+                <_>
+                  20 11 5 2 2.</_>
+                <_>
+                  15 13 5 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>5.1532038487493992e-003</threshold>
+            <left_val>-0.1119574010372162</left_val>
+            <right_val>0.1447393000125885</right_val></_></_>
+        <_>
+          <!-- tree 38 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 5 18 10 -1.</_>
+                <_>
+                  2 5 9 5 2.</_>
+                <_>
+                  11 10 9 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0117915198206902</threshold>
+            <left_val>0.0826227068901062</left_val>
+            <right_val>-0.3599678874015808</right_val></_></_>
+        <_>
+          <!-- tree 39 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 3 7 12 -1.</_>
+                <_>
+                  18 9 7 6 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.1839103996753693</threshold>
+            <left_val>6.3381828367710114e-003</left_val>
+            <right_val>-0.6336789131164551</right_val></_></_>
+        <_>
+          <!-- tree 40 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 5 24 10 -1.</_>
+                <_>
+                  0 5 12 5 2.</_>
+                <_>
+                  12 10 12 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.2286608070135117</threshold>
+            <left_val>-0.4835804998874664</left_val>
+            <right_val>0.0630095899105072</right_val></_></_>
+        <_>
+          <!-- tree 41 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 0 9 8 -1.</_>
+                <_>
+                  11 0 3 8 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0191301498562098</threshold>
+            <left_val>0.4357733130455017</left_val>
+            <right_val>-0.0737645477056503</right_val></_></_></trees>
+      <stage_threshold>-1.3057390451431274</stage_threshold>
+      <parent>7</parent>
+      <next>-1</next></_>
+    <_>
+      <!-- stage 9 -->
+      <trees>
+        <_>
+          <!-- tree 0 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 2 6 3 -1.</_>
+                <_>
+                  3 2 3 3 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.4189989566802979e-003</threshold>
+            <left_val>0.4113925993442535</left_val>
+            <right_val>-0.3249151110649109</right_val></_></_>
+        <_>
+          <!-- tree 1 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 4 18 10 -1.</_>
+                <_>
+                  16 4 9 5 2.</_>
+                <_>
+                  7 9 9 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0146306799724698</threshold>
+            <left_val>0.1793731003999710</left_val>
+            <right_val>-0.2603518962860107</right_val></_></_>
+        <_>
+          <!-- tree 2 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 4 20 10 -1.</_>
+                <_>
+                  0 4 10 5 2.</_>
+                <_>
+                  10 9 10 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0610242486000061</threshold>
+            <left_val>0.2256585955619812</left_val>
+            <right_val>-0.4320737123489380</right_val></_></_>
+        <_>
+          <!-- tree 3 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 8 12 4 -1.</_>
+                <_>
+                  14 8 4 4 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0139595195651054</threshold>
+            <left_val>-0.1441860944032669</left_val>
+            <right_val>0.2447797060012817</right_val></_></_>
+        <_>
+          <!-- tree 4 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 12 15 2 -1.</_>
+                <_>
+                  5 13 15 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.5069060288369656e-003</threshold>
+            <left_val>-0.2392694950103760</left_val>
+            <right_val>0.2571214139461517</right_val></_></_>
+        <_>
+          <!-- tree 5 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 0 2 1 -1.</_>
+                <_>
+                  13 0 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-6.9540529511868954e-004</threshold>
+            <left_val>0.2799463868141174</left_val>
+            <right_val>-0.0736822411417961</right_val></_></_>
+        <_>
+          <!-- tree 6 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 0 9 1 -1.</_>
+                <_>
+                  11 0 3 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.8362470436841249e-003</threshold>
+            <left_val>-0.2962667047977448</left_val>
+            <right_val>0.2125633060932159</right_val></_></_>
+        <_>
+          <!-- tree 7 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 2 15 8 -1.</_>
+                <_>
+                  5 4 15 4 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0383301191031933</threshold>
+            <left_val>-0.2875585854053497</left_val>
+            <right_val>0.1625593006610870</right_val></_></_>
+        <_>
+          <!-- tree 8 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 0 3 14 -1.</_>
+                <_>
+                  8 0 1 14 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.9957321025431156e-003</threshold>
+            <left_val>0.0513833202421665</left_val>
+            <right_val>-0.7606527805328369</right_val></_></_>
+        <_>
+          <!-- tree 9 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 1 6 2 -1.</_>
+                <_>
+                  14 1 3 1 2.</_>
+                <_>
+                  11 2 3 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-6.1175678856670856e-003</threshold>
+            <left_val>-0.6863374114036560</left_val>
+            <right_val>8.9805321767926216e-003</right_val></_></_>
+        <_>
+          <!-- tree 10 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 1 7 6 -1.</_>
+                <_>
+                  4 4 7 3 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0440180897712708</threshold>
+            <left_val>0.0500780716538429</left_val>
+            <right_val>-0.6486299037933350</right_val></_></_>
+        <_>
+          <!-- tree 11 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 7 8 4 -1.</_>
+                <_>
+                  15 7 4 2 2.</_>
+                <_>
+                  11 9 4 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.0852491036057472e-003</threshold>
+            <left_val>-0.1025620028376579</left_val>
+            <right_val>0.1471097022294998</right_val></_></_>
+        <_>
+          <!-- tree 12 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 4 3 11 -1.</_>
+                <_>
+                  8 4 1 11 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-9.1778011992573738e-003</threshold>
+            <left_val>-0.6964817047119141</left_val>
+            <right_val>0.0484346412122250</right_val></_></_>
+        <_>
+          <!-- tree 13 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 6 9 9 -1.</_>
+                <_>
+                  15 6 3 9 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.1223298013210297</threshold>
+            <left_val>-0.7142469286918640</left_val>
+            <right_val>-5.9244427829980850e-003</right_val></_></_>
+        <_>
+          <!-- tree 14 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 6 9 9 -1.</_>
+                <_>
+                  7 6 3 9 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0201609302312136</threshold>
+            <left_val>0.1930653005838394</left_val>
+            <right_val>-0.2045785933732987</right_val></_></_>
+        <_>
+          <!-- tree 15 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 0 18 13 -1.</_>
+                <_>
+                  12 0 6 13 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0806815922260284</threshold>
+            <left_val>-0.1496978998184204</left_val>
+            <right_val>0.0688701719045639</right_val></_></_>
+        <_>
+          <!-- tree 16 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  1 0 18 13 -1.</_>
+                <_>
+                  7 0 6 13 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.2023846954107285</threshold>
+            <left_val>-0.0828868672251701</left_val>
+            <right_val>0.5090026855468750</right_val></_></_>
+        <_>
+          <!-- tree 17 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 0 2 4 -1.</_>
+                <_>
+                  18 0 1 4 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0140059497207403</threshold>
+            <left_val>0.0403110198676586</left_val>
+            <right_val>-0.5785480737686157</right_val></_></_>
+        <_>
+          <!-- tree 18 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 3 18 8 -1.</_>
+                <_>
+                  9 3 9 8 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.3143957853317261</threshold>
+            <left_val>0.0622985512018204</left_val>
+            <right_val>-0.5402104258537293</right_val></_></_>
+        <_>
+          <!-- tree 19 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 1 2 2 -1.</_>
+                <_>
+                  12 1 1 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-6.8189308512955904e-004</threshold>
+            <left_val>0.1866507977247238</left_val>
+            <right_val>-0.1640997976064682</right_val></_></_>
+        <_>
+          <!-- tree 20 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 4 3 1 -1.</_>
+                <_>
+                  12 4 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.8724791374988854e-004</threshold>
+            <left_val>-0.5398725867271423</left_val>
+            <right_val>0.0625192821025848</right_val></_></_>
+        <_>
+          <!-- tree 21 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 8 8 2 -1.</_>
+                <_>
+                  14 8 4 1 2.</_>
+                <_>
+                  10 9 4 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.2638779589906335e-003</threshold>
+            <left_val>0.0646254122257233</left_val>
+            <right_val>-0.0505444183945656</right_val></_></_>
+        <_>
+          <!-- tree 22 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 7 8 4 -1.</_>
+                <_>
+                  6 7 4 2 2.</_>
+                <_>
+                  10 9 4 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.5873379781842232e-003</threshold>
+            <left_val>-0.1021538004279137</left_val>
+            <right_val>0.3074747920036316</right_val></_></_>
+        <_>
+          <!-- tree 23 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  17 8 3 3 -1.</_>
+                <_>
+                  18 9 1 3 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-6.8068611435592175e-003</threshold>
+            <left_val>0.1493643969297409</left_val>
+            <right_val>-0.0699878931045532</right_val></_></_>
+        <_>
+          <!-- tree 24 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 8 3 3 -1.</_>
+                <_>
+                  7 9 3 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>3.0861350242048502e-003</threshold>
+            <left_val>-0.1021168008446693</left_val>
+            <right_val>0.3267554938793182</right_val></_></_>
+        <_>
+          <!-- tree 25 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 0 12 4 -1.</_>
+                <_>
+                  10 2 12 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0393678992986679</threshold>
+            <left_val>0.0385903418064117</left_val>
+            <right_val>-0.5895259976387024</right_val></_></_>
+        <_>
+          <!-- tree 26 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 0 12 4 -1.</_>
+                <_>
+                  4 2 12 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0187464803457260</threshold>
+            <left_val>-0.5414584875106812</left_val>
+            <right_val>0.0629050731658936</right_val></_></_>
+        <_>
+          <!-- tree 27 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 9 3 5 -1.</_>
+                <_>
+                  12 9 1 5 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.6627619303762913e-003</threshold>
+            <left_val>0.0333267711102962</left_val>
+            <right_val>-0.8152747154235840</right_val></_></_>
+        <_>
+          <!-- tree 28 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 3 3 10 -1.</_>
+                <_>
+                  5 3 1 10 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>7.5963549315929413e-003</threshold>
+            <left_val>0.0221978500485420</left_val>
+            <right_val>-0.9193025827407837</right_val></_></_>
+        <_>
+          <!-- tree 29 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 0 3 4 -1.</_>
+                <_>
+                  22 1 3 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.2214960297569633e-003</threshold>
+            <left_val>-0.1286098062992096</left_val>
+            <right_val>0.2160543948411942</right_val></_></_>
+        <_>
+          <!-- tree 30 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 3 3 1 -1.</_>
+                <_>
+                  1 3 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.0978960199281573e-003</threshold>
+            <left_val>0.0399320200085640</left_val>
+            <right_val>-0.7397419810295105</right_val></_></_>
+        <_>
+          <!-- tree 31 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 12 2 2 -1.</_>
+                <_>
+                  14 12 1 1 2.</_>
+                <_>
+                  13 13 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.5113380504772067e-004</threshold>
+            <left_val>-0.0855182632803917</left_val>
+            <right_val>0.1250717043876648</right_val></_></_>
+        <_>
+          <!-- tree 32 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 12 2 2 -1.</_>
+                <_>
+                  10 12 1 1 2.</_>
+                <_>
+                  11 13 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.2872861376963556e-004</threshold>
+            <left_val>0.2906106114387512</left_val>
+            <right_val>-0.0981541723012924</right_val></_></_>
+        <_>
+          <!-- tree 33 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 13 3 2 -1.</_>
+                <_>
+                  12 13 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.7771900165826082e-003</threshold>
+            <left_val>-0.7337031960487366</left_val>
+            <right_val>0.0424608998000622</right_val></_></_>
+        <_>
+          <!-- tree 34 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 11 7 3 -1.</_>
+                <_>
+                  4 12 7 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.6987440176308155e-003</threshold>
+            <left_val>-0.1372476965188980</left_val>
+            <right_val>0.2080529034137726</right_val></_></_>
+        <_>
+          <!-- tree 35 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  23 9 1 4 -1.</_>
+                <_>
+                  23 11 1 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>9.3073211610317230e-003</threshold>
+            <left_val>0.0238540899008513</left_val>
+            <right_val>-0.4354343116283417</right_val></_></_>
+        <_>
+          <!-- tree 36 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 1 5 14 -1.</_>
+                <_>
+                  2 8 5 7 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0523535683751106</threshold>
+            <left_val>0.0615307502448559</left_val>
+            <right_val>-0.4818547070026398</right_val></_></_>
+        <_>
+          <!-- tree 37 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 6 3 9 -1.</_>
+                <_>
+                  23 9 1 3 9.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0108097000047565</threshold>
+            <left_val>-0.0486800409853458</left_val>
+            <right_val>0.0978717803955078</right_val></_></_>
+        <_>
+          <!-- tree 38 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 4 2 2 -1.</_>
+                <_>
+                  9 4 1 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>6.7173343268223107e-005</threshold>
+            <left_val>-0.2636834979057312</left_val>
+            <right_val>0.1064359992742539</right_val></_></_>
+        <_>
+          <!-- tree 39 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 0 3 15 -1.</_>
+                <_>
+                  23 0 1 15 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>8.0847600474953651e-003</threshold>
+            <left_val>0.0278695598244667</left_val>
+            <right_val>-0.7440199851989746</right_val></_></_>
+        <_>
+          <!-- tree 40 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 0 9 2 -1.</_>
+                <_>
+                  6 1 9 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0102138696238399</threshold>
+            <left_val>0.0318613313138485</left_val>
+            <right_val>-0.7084450125694275</right_val></_></_>
+        <_>
+          <!-- tree 41 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 7 3 2 -1.</_>
+                <_>
+                  21 7 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.2496729614213109e-003</threshold>
+            <left_val>0.2949855029582977</left_val>
+            <right_val>-0.1047601997852325</right_val></_></_>
+        <_>
+          <!-- tree 42 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 12 3 1 -1.</_>
+                <_>
+                  1 12 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-6.3889409648254514e-004</threshold>
+            <left_val>-0.6539766192436218</left_val>
+            <right_val>0.0472203493118286</right_val></_></_>
+        <_>
+          <!-- tree 43 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 6 3 3 -1.</_>
+                <_>
+                  21 6 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.4924929710105062e-003</threshold>
+            <left_val>-0.1034428030252457</left_val>
+            <right_val>0.3508220911026001</right_val></_></_>
+        <_>
+          <!-- tree 44 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 1 4 3 -1.</_>
+                <_>
+                  6 2 2 3 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>7.8329853713512421e-003</threshold>
+            <left_val>-0.0704268664121628</left_val>
+            <right_val>0.3735159039497376</right_val></_></_>
+        <_>
+          <!-- tree 45 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  17 2 6 3 -1.</_>
+                <_>
+                  16 3 6 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-5.0054159946739674e-003</threshold>
+            <left_val>0.1885109990835190</left_val>
+            <right_val>-0.0395105890929699</right_val></_></_>
+        <_>
+          <!-- tree 46 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 2 3 6 -1.</_>
+                <_>
+                  9 3 1 6 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>9.2800334095954895e-003</threshold>
+            <left_val>-0.0838543474674225</left_val>
+            <right_val>0.3293943107128143</right_val></_></_>
+        <_>
+          <!-- tree 47 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 2 3 8 -1.</_>
+                <_>
+                  23 2 1 8 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.5133759267628193e-003</threshold>
+            <left_val>-0.6392177939414978</left_val>
+            <right_val>0.0569349788129330</right_val></_></_>
+        <_>
+          <!-- tree 48 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 2 3 8 -1.</_>
+                <_>
+                  1 2 1 8 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.7245869170874357e-003</threshold>
+            <left_val>-0.7164484262466431</left_val>
+            <right_val>0.0309775993227959</right_val></_></_>
+        <_>
+          <!-- tree 49 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 0 3 1 -1.</_>
+                <_>
+                  12 0 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.2676969636231661e-003</threshold>
+            <left_val>0.0289017092436552</left_val>
+            <right_val>-0.7310838103294373</right_val></_></_></trees>
+      <stage_threshold>-1.3268710374832153</stage_threshold>
+      <parent>8</parent>
+      <next>-1</next></_>
+    <_>
+      <!-- stage 10 -->
+      <trees>
+        <_>
+          <!-- tree 0 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 6 4 4 -1.</_>
+                <_>
+                  9 7 4 2 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-0.0169341601431370</threshold>
+            <left_val>0.4096024036407471</left_val>
+            <right_val>-0.2540819942951202</right_val></_></_>
+        <_>
+          <!-- tree 1 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  16 0 1 12 -1.</_>
+                <_>
+                  12 4 1 4 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-0.0358569510281086</threshold>
+            <left_val>-0.1143561974167824</left_val>
+            <right_val>0.0202446505427361</right_val></_></_>
+        <_>
+          <!-- tree 2 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 0 2 3 -1.</_>
+                <_>
+                  12 0 1 3 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.2413900112733245e-003</threshold>
+            <left_val>-0.2525601089000702</left_val>
+            <right_val>0.2967867851257324</right_val></_></_>
+        <_>
+          <!-- tree 3 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 2 15 9 -1.</_>
+                <_>
+                  5 5 15 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0724700465798378</threshold>
+            <left_val>-0.3872064948081970</left_val>
+            <right_val>0.1508696973323822</right_val></_></_>
+        <_>
+          <!-- tree 4 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 0 21 7 -1.</_>
+                <_>
+                  9 0 7 7 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0893332436680794</threshold>
+            <left_val>-0.2452031970024109</left_val>
+            <right_val>0.2145949006080627</right_val></_></_>
+        <_>
+          <!-- tree 5 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  23 5 2 1 -1.</_>
+                <_>
+                  23 5 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.2586278393864632e-005</threshold>
+            <left_val>0.1354901045560837</left_val>
+            <right_val>-0.1178793013095856</right_val></_></_>
+        <_>
+          <!-- tree 6 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 0 9 6 -1.</_>
+                <_>
+                  4 3 9 3 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0481269508600235</threshold>
+            <left_val>0.0803330913186073</left_val>
+            <right_val>-0.6501892805099487</right_val></_></_>
+        <_>
+          <!-- tree 7 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 3 2 1 -1.</_>
+                <_>
+                  22 3 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-5.9438309108372778e-005</threshold>
+            <left_val>0.1065364032983780</left_val>
+            <right_val>-0.0720233768224716</right_val></_></_>
+        <_>
+          <!-- tree 8 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  1 3 2 1 -1.</_>
+                <_>
+                  2 3 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-6.2002181948628277e-005</threshold>
+            <left_val>0.1790948957204819</left_val>
+            <right_val>-0.2305728942155838</right_val></_></_>
+        <_>
+          <!-- tree 9 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 0 4 3 -1.</_>
+                <_>
+                  15 0 2 3 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0426334999501705</threshold>
+            <left_val>7.0221549831330776e-003</left_val>
+            <right_val>-0.6957908272743225</right_val></_></_>
+        <_>
+          <!-- tree 10 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 0 14 11 -1.</_>
+                <_>
+                  9 0 7 11 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.3315657079219818</threshold>
+            <left_val>0.0718551129102707</left_val>
+            <right_val>-0.5884742736816406</right_val></_></_>
+        <_>
+          <!-- tree 11 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 9 6 2 -1.</_>
+                <_>
+                  15 9 3 1 2.</_>
+                <_>
+                  12 10 3 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.8693020101636648e-003</threshold>
+            <left_val>-0.0806239098310471</left_val>
+            <right_val>0.1444675028324127</right_val></_></_>
+        <_>
+          <!-- tree 12 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 4 5 8 -1.</_>
+                <_>
+                  0 8 5 4 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0770097374916077</threshold>
+            <left_val>-0.5667830109596252</left_val>
+            <right_val>0.0828577727079391</right_val></_></_>
+        <_>
+          <!-- tree 13 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  16 7 2 4 -1.</_>
+                <_>
+                  16 8 2 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.9142080564051867e-003</threshold>
+            <left_val>0.1334667056798935</left_val>
+            <right_val>-0.0949927866458893</right_val></_></_>
+        <_>
+          <!-- tree 14 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 7 2 4 -1.</_>
+                <_>
+                  7 8 2 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.7394910100847483e-003</threshold>
+            <left_val>-0.1191345974802971</left_val>
+            <right_val>0.3233923912048340</right_val></_></_>
+        <_>
+          <!-- tree 15 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  9 0 14 4 -1.</_>
+                <_>
+                  9 2 14 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0344879887998104</threshold>
+            <left_val>-0.7731835842132568</left_val>
+            <right_val>0.0292332805693150</right_val></_></_>
+        <_>
+          <!-- tree 16 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 0 3 15 -1.</_>
+                <_>
+                  5 0 1 15 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-8.8623687624931335e-003</threshold>
+            <left_val>-0.7552136182785034</left_val>
+            <right_val>0.0338150113821030</right_val></_></_>
+        <_>
+          <!-- tree 17 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 0 5 3 -1.</_>
+                <_>
+                  19 1 5 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>9.3052461743354797e-003</threshold>
+            <left_val>-0.0621602684259415</left_val>
+            <right_val>0.3539577126502991</right_val></_></_>
+        <_>
+          <!-- tree 18 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 0 3 5 -1.</_>
+                <_>
+                  6 1 1 5 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>4.7184950672090054e-003</threshold>
+            <left_val>-0.0905603393912315</left_val>
+            <right_val>0.3343018889427185</right_val></_></_>
+        <_>
+          <!-- tree 19 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 0 2 2 -1.</_>
+                <_>
+                  13 0 1 1 2.</_>
+                <_>
+                  12 1 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.0957351302495226e-005</threshold>
+            <left_val>-0.1335009038448334</left_val>
+            <right_val>0.2036238014698029</right_val></_></_>
+        <_>
+          <!-- tree 20 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 3 3 4 -1.</_>
+                <_>
+                  7 4 1 4 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>4.8206620849668980e-003</threshold>
+            <left_val>-0.1071285977959633</left_val>
+            <right_val>0.2612333893775940</right_val></_></_>
+        <_>
+          <!-- tree 21 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  17 0 8 15 -1.</_>
+                <_>
+                  17 5 8 5 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.3241918087005615</threshold>
+            <left_val>0.0198021195828915</left_val>
+            <right_val>-0.6098077297210693</right_val></_></_>
+        <_>
+          <!-- tree 22 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 0 2 4 -1.</_>
+                <_>
+                  3 1 2 2 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-4.8380480147898197e-003</threshold>
+            <left_val>-0.4872285127639771</left_val>
+            <right_val>0.0582287199795246</right_val></_></_>
+        <_>
+          <!-- tree 23 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 7 3 2 -1.</_>
+                <_>
+                  21 7 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.2000199640169740e-003</threshold>
+            <left_val>-0.0713948607444763</left_val>
+            <right_val>0.2222888022661209</right_val></_></_>
+        <_>
+          <!-- tree 24 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 6 3 1 -1.</_>
+                <_>
+                  5 6 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.1394190369173884e-003</threshold>
+            <left_val>0.0397342406213284</left_val>
+            <right_val>-0.7411820292472839</right_val></_></_>
+        <_>
+          <!-- tree 25 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 7 3 2 -1.</_>
+                <_>
+                  21 7 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.0889209806919098e-003</threshold>
+            <left_val>0.2107442021369934</left_val>
+            <right_val>-0.1025888025760651</right_val></_></_>
+        <_>
+          <!-- tree 26 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 7 3 2 -1.</_>
+                <_>
+                  3 7 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.0484729427844286e-003</threshold>
+            <left_val>0.3064717054367065</left_val>
+            <right_val>-0.0934595465660095</right_val></_></_>
+        <_>
+          <!-- tree 27 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 7 3 8 -1.</_>
+                <_>
+                  23 7 1 8 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-2.2499570623040199e-003</threshold>
+            <left_val>-0.5368850231170654</left_val>
+            <right_val>0.0783103033900261</right_val></_></_>
+        <_>
+          <!-- tree 28 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 0 2 2 -1.</_>
+                <_>
+                  10 0 1 1 2.</_>
+                <_>
+                  11 1 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-7.1653863415122032e-005</threshold>
+            <left_val>0.1992810070514679</left_val>
+            <right_val>-0.1428865045309067</right_val></_></_>
+        <_>
+          <!-- tree 29 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 6 3 1 -1.</_>
+                <_>
+                  12 6 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.4780029091052711e-004</threshold>
+            <left_val>-0.4854441881179810</left_val>
+            <right_val>0.0634147599339485</right_val></_></_>
+        <_>
+          <!-- tree 30 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 12 2 2 -1.</_>
+                <_>
+                  4 12 1 1 2.</_>
+                <_>
+                  5 13 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.8983878766885027e-005</threshold>
+            <left_val>-0.1671497970819473</left_val>
+            <right_val>0.1667871028184891</right_val></_></_>
+        <_>
+          <!-- tree 31 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 8 3 7 -1.</_>
+                <_>
+                  23 8 1 7 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>5.3126700222492218e-003</threshold>
+            <left_val>0.0307516790926456</left_val>
+            <right_val>-0.6744030714035034</right_val></_></_>
+        <_>
+          <!-- tree 32 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 1 24 8 -1.</_>
+                <_>
+                  0 1 12 4 2.</_>
+                <_>
+                  12 5 12 4 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0886742472648621</threshold>
+            <left_val>-0.4365026950836182</left_val>
+            <right_val>0.0571731291711330</right_val></_></_>
+        <_>
+          <!-- tree 33 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  1 0 24 12 -1.</_>
+                <_>
+                  13 0 12 6 2.</_>
+                <_>
+                  1 6 12 6 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.1396493017673492</threshold>
+            <left_val>-0.5136963129043579</left_val>
+            <right_val>0.0610323995351791</right_val></_></_>
+        <_>
+          <!-- tree 34 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 7 3 3 -1.</_>
+                <_>
+                  3 7 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.3536589685827494e-003</threshold>
+            <left_val>-0.1026685982942581</left_val>
+            <right_val>0.2779572010040283</right_val></_></_>
+        <_>
+          <!-- tree 35 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  23 9 2 2 -1.</_>
+                <_>
+                  23 9 1 2 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-1.4373889425769448e-003</threshold>
+            <left_val>0.2075044065713882</left_val>
+            <right_val>-0.1547268033027649</right_val></_></_>
+        <_>
+          <!-- tree 36 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 7 7 8 -1.</_>
+                <_>
+                  0 11 7 4 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0788289383053780</threshold>
+            <left_val>0.0540495999157429</left_val>
+            <right_val>-0.5201445221900940</right_val></_></_>
+        <_>
+          <!-- tree 37 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  23 9 2 2 -1.</_>
+                <_>
+                  23 9 1 2 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0119665199890733</threshold>
+            <left_val>-0.0207872707396746</left_val>
+            <right_val>0.4531430006027222</right_val></_></_>
+        <_>
+          <!-- tree 38 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 9 2 2 -1.</_>
+                <_>
+                  2 9 2 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>4.7745471820235252e-003</threshold>
+            <left_val>0.0668162703514099</left_val>
+            <right_val>-0.4944655001163483</right_val></_></_>
+        <_>
+          <!-- tree 39 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 1 3 1 -1.</_>
+                <_>
+                  19 1 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>7.9897989053279161e-004</threshold>
+            <left_val>0.0379552915692329</left_val>
+            <right_val>-0.6262574791908264</right_val></_></_>
+        <_>
+          <!-- tree 40 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 1 3 1 -1.</_>
+                <_>
+                  5 1 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>6.6447007702663541e-004</threshold>
+            <left_val>0.0360684394836426</left_val>
+            <right_val>-0.6018475294113159</right_val></_></_>
+        <_>
+          <!-- tree 41 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 0 2 2 -1.</_>
+                <_>
+                  14 0 1 1 2.</_>
+                <_>
+                  13 1 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.1683648305479437e-005</threshold>
+            <left_val>0.0987836793065071</left_val>
+            <right_val>-0.0742472633719444</right_val></_></_>
+        <_>
+          <!-- tree 42 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 0 2 2 -1.</_>
+                <_>
+                  10 0 1 1 2.</_>
+                <_>
+                  11 1 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>5.7580178690841421e-005</threshold>
+            <left_val>-0.1371214985847473</left_val>
+            <right_val>0.2008657008409500</right_val></_></_>
+        <_>
+          <!-- tree 43 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 11 2 2 -1.</_>
+                <_>
+                  14 11 1 1 2.</_>
+                <_>
+                  13 12 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.2264260041993111e-004</threshold>
+            <left_val>-0.0668121427297592</left_val>
+            <right_val>0.1486620008945465</right_val></_></_>
+        <_>
+          <!-- tree 44 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 9 3 5 -1.</_>
+                <_>
+                  1 9 1 5 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.5256210248917341e-003</threshold>
+            <left_val>0.0366611704230309</left_val>
+            <right_val>-0.6888226866722107</right_val></_></_>
+        <_>
+          <!-- tree 45 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  21 7 2 2 -1.</_>
+                <_>
+                  22 7 1 1 2.</_>
+                <_>
+                  21 8 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.7152061122469604e-004</threshold>
+            <left_val>0.2102985978126526</left_val>
+            <right_val>-0.1097417995333672</right_val></_></_>
+        <_>
+          <!-- tree 46 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 2 3 4 -1.</_>
+                <_>
+                  6 3 1 4 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0100473696365952</threshold>
+            <left_val>-0.0561960898339748</left_val>
+            <right_val>0.4531404078006744</right_val></_></_>
+        <_>
+          <!-- tree 47 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  14 1 2 1 -1.</_>
+                <_>
+                  14 1 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>8.2131160888820887e-004</threshold>
+            <left_val>-0.0731681808829308</left_val>
+            <right_val>0.2967571914196014</right_val></_></_>
+        <_>
+          <!-- tree 48 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 2 3 1 -1.</_>
+                <_>
+                  12 2 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>8.4035459440201521e-004</threshold>
+            <left_val>0.0542908906936646</left_val>
+            <right_val>-0.5217555165290833</right_val></_></_>
+        <_>
+          <!-- tree 49 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 0 12 13 -1.</_>
+                <_>
+                  7 0 6 13 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.1373244971036911</threshold>
+            <left_val>0.1733210980892181</left_val>
+            <right_val>-0.1457879990339279</right_val></_></_>
+        <_>
+          <!-- tree 50 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 7 4 2 -1.</_>
+                <_>
+                  8 7 4 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0136272795498371</threshold>
+            <left_val>-0.0740842670202255</left_val>
+            <right_val>0.4016517102718353</right_val></_></_>
+        <_>
+          <!-- tree 51 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 9 3 4 -1.</_>
+                <_>
+                  15 10 3 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-2.4706069380044937e-003</threshold>
+            <left_val>0.1014207974076271</left_val>
+            <right_val>-0.0921628773212433</right_val></_></_>
+        <_>
+          <!-- tree 52 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 9 4 4 -1.</_>
+                <_>
+                  7 10 4 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.1348390039056540e-003</threshold>
+            <left_val>-0.0988634899258614</left_val>
+            <right_val>0.3391206860542297</right_val></_></_>
+        <_>
+          <!-- tree 53 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  16 4 2 1 -1.</_>
+                <_>
+                  16 4 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.9346130506601185e-005</threshold>
+            <left_val>-0.1338652968406677</left_val>
+            <right_val>0.1049982979893684</right_val></_></_>
+        <_>
+          <!-- tree 54 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 4 2 1 -1.</_>
+                <_>
+                  8 4 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.1285781005863100e-005</threshold>
+            <left_val>-0.2170958966016769</left_val>
+            <right_val>0.1260405927896500</right_val></_></_>
+        <_>
+          <!-- tree 55 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 2 2 1 -1.</_>
+                <_>
+                  15 2 1 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-5.4424027912318707e-003</threshold>
+            <left_val>-0.6767864823341370</left_val>
+            <right_val>0.0130751999095082</right_val></_></_>
+        <_>
+          <!-- tree 56 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 0 12 7 -1.</_>
+                <_>
+                  9 0 6 7 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0196178294718266</threshold>
+            <left_val>0.3731184005737305</left_val>
+            <right_val>-0.0871373713016510</right_val></_></_>
+        <_>
+          <!-- tree 57 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 2 3 2 -1.</_>
+                <_>
+                  12 2 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.6730449210153893e-005</threshold>
+            <left_val>-0.2187726944684982</left_val>
+            <right_val>0.1412795931100845</right_val></_></_>
+        <_>
+          <!-- tree 58 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 2 1 2 -1.</_>
+                <_>
+                  10 2 1 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>3.6985049955546856e-003</threshold>
+            <left_val>0.0354966707527637</left_val>
+            <right_val>-0.6833251118659973</right_val></_></_>
+        <_>
+          <!-- tree 59 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 0 7 3 -1.</_>
+                <_>
+                  18 1 7 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>8.3659641677513719e-004</threshold>
+            <left_val>-0.0990597531199455</left_val>
+            <right_val>0.1288201063871384</right_val></_></_>
+        <_>
+          <!-- tree 60 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 11 2 2 -1.</_>
+                <_>
+                  10 11 1 1 2.</_>
+                <_>
+                  11 12 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-6.4976088469848037e-004</threshold>
+            <left_val>0.3258321881294251</left_val>
+            <right_val>-0.0790102109313011</right_val></_></_>
+        <_>
+          <!-- tree 61 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 11 2 2 -1.</_>
+                <_>
+                  14 11 1 1 2.</_>
+                <_>
+                  13 12 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.7926358345430344e-005</threshold>
+            <left_val>0.0822571814060211</left_val>
+            <right_val>-0.0522799193859100</right_val></_></_>
+        <_>
+          <!-- tree 62 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 11 2 2 -1.</_>
+                <_>
+                  10 11 1 1 2.</_>
+                <_>
+                  11 12 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.5765200047753751e-004</threshold>
+            <left_val>-0.0916395410895348</left_val>
+            <right_val>0.3068880140781403</right_val></_></_></trees>
+      <stage_threshold>-1.4012360572814941</stage_threshold>
+      <parent>9</parent>
+      <next>-1</next></_>
+    <_>
+      <!-- stage 11 -->
+      <trees>
+        <_>
+          <!-- tree 0 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 6 4 8 -1.</_>
+                <_>
+                  7 8 4 4 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0184314101934433</threshold>
+            <left_val>0.2463490068912506</left_val>
+            <right_val>-0.3171863853931427</right_val></_></_>
+        <_>
+          <!-- tree 1 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 0 12 3 -1.</_>
+                <_>
+                  15 0 4 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0191712807863951</threshold>
+            <left_val>-0.0968664288520813</left_val>
+            <right_val>0.1506159007549286</right_val></_></_>
+        <_>
+          <!-- tree 2 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 0 9 7 -1.</_>
+                <_>
+                  11 0 3 7 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0230059698224068</threshold>
+            <left_val>-0.2472759932279587</left_val>
+            <right_val>0.2520915865898132</right_val></_></_>
+        <_>
+          <!-- tree 3 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 7 12 8 -1.</_>
+                <_>
+                  13 7 6 8 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0761691331863403</threshold>
+            <left_val>-0.4557226896286011</left_val>
+            <right_val>0.0684080496430397</right_val></_></_>
+        <_>
+          <!-- tree 4 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 1 9 1 -1.</_>
+                <_>
+                  15 4 3 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0285642705857754</threshold>
+            <left_val>-0.2250320017337799</left_val>
+            <right_val>0.1829531937837601</right_val></_></_>
+        <_>
+          <!-- tree 5 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  16 10 8 4 -1.</_>
+                <_>
+                  16 10 4 4 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0119428504258394</threshold>
+            <left_val>0.2196357995271683</left_val>
+            <right_val>-0.1170701980590820</right_val></_></_>
+        <_>
+          <!-- tree 6 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 10 8 5 -1.</_>
+                <_>
+                  4 10 4 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0102799795567989</threshold>
+            <left_val>0.1598898023366928</left_val>
+            <right_val>-0.2303328961133957</right_val></_></_>
+        <_>
+          <!-- tree 7 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 8 3 3 -1.</_>
+                <_>
+                  12 8 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-9.2266657156869769e-004</threshold>
+            <left_val>-0.4794006943702698</left_val>
+            <right_val>0.0850129276514053</right_val></_></_>
+        <_>
+          <!-- tree 8 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 1 9 4 -1.</_>
+                <_>
+                  6 3 9 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0284100901335478</threshold>
+            <left_val>0.0481950193643570</left_val>
+            <right_val>-0.6189708113670349</right_val></_></_>
+        <_>
+          <!-- tree 9 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 0 12 2 -1.</_>
+                <_>
+                  15 0 4 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0133093502372503</threshold>
+            <left_val>0.1536156982183456</left_val>
+            <right_val>-0.0488003082573414</right_val></_></_>
+        <_>
+          <!-- tree 10 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  1 0 15 1 -1.</_>
+                <_>
+                  6 0 5 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-8.2416953518986702e-003</threshold>
+            <left_val>0.1810190975666046</left_val>
+            <right_val>-0.2060683071613312</right_val></_></_>
+        <_>
+          <!-- tree 11 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  16 8 4 3 -1.</_>
+                <_>
+                  16 9 4 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-5.9963939711451530e-003</threshold>
+            <left_val>0.1586516052484512</left_val>
+            <right_val>-0.0665248483419418</right_val></_></_>
+        <_>
+          <!-- tree 12 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 9 15 2 -1.</_>
+                <_>
+                  5 10 15 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0195911303162575</threshold>
+            <left_val>0.2811712026596069</left_val>
+            <right_val>-0.1220393031835556</right_val></_></_>
+        <_>
+          <!-- tree 13 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  14 9 5 2 -1.</_>
+                <_>
+                  14 10 5 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.4191512279212475e-003</threshold>
+            <left_val>-0.0434971898794174</left_val>
+            <right_val>0.2540419101715088</right_val></_></_>
+        <_>
+          <!-- tree 14 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 14 3 1 -1.</_>
+                <_>
+                  5 14 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-6.7615607986226678e-004</threshold>
+            <left_val>-0.5545126199722290</left_val>
+            <right_val>0.0603439100086689</right_val></_></_>
+        <_>
+          <!-- tree 15 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 14 3 1 -1.</_>
+                <_>
+                  19 14 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-9.4205717323347926e-004</threshold>
+            <left_val>-0.5951253771781921</left_val>
+            <right_val>0.0327010415494442</right_val></_></_>
+        <_>
+          <!-- tree 16 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 9 2 2 -1.</_>
+                <_>
+                  7 10 2 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.9710098858922720e-003</threshold>
+            <left_val>-0.0961277484893799</left_val>
+            <right_val>0.3226830065250397</right_val></_></_>
+        <_>
+          <!-- tree 17 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 4 3 8 -1.</_>
+                <_>
+                  12 4 1 8 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>6.6142040304839611e-003</threshold>
+            <left_val>0.0404138602316380</left_val>
+            <right_val>-0.6547585129737854</right_val></_></_>
+        <_>
+          <!-- tree 18 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 5 3 1 -1.</_>
+                <_>
+                  12 5 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.9419340211898088e-004</threshold>
+            <left_val>-0.5925490260124207</left_val>
+            <right_val>0.0436622612178326</right_val></_></_>
+        <_>
+          <!-- tree 19 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 5 3 1 -1.</_>
+                <_>
+                  23 6 1 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>9.3889115378260612e-003</threshold>
+            <left_val>3.9889588952064514e-003</left_val>
+            <right_val>-0.4474850893020630</right_val></_></_>
+        <_>
+          <!-- tree 20 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 8 5 3 -1.</_>
+                <_>
+                  5 9 5 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.1060320325195789e-003</threshold>
+            <left_val>-0.0990559086203575</left_val>
+            <right_val>0.2773069143295288</right_val></_></_>
+        <_>
+          <!-- tree 21 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 1 3 1 -1.</_>
+                <_>
+                  16 1 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-9.6447288524359465e-004</threshold>
+            <left_val>-0.5962548255920410</left_val>
+            <right_val>0.0407463796436787</right_val></_></_>
+        <_>
+          <!-- tree 22 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 0 24 8 -1.</_>
+                <_>
+                  0 0 12 4 2.</_>
+                <_>
+                  12 4 12 4 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0644117891788483</threshold>
+            <left_val>-0.4076926112174988</left_val>
+            <right_val>0.0575844198465347</right_val></_></_>
+        <_>
+          <!-- tree 23 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 0 2 1 -1.</_>
+                <_>
+                  22 0 1 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>3.9425520226359367e-003</threshold>
+            <left_val>0.0241970494389534</left_val>
+            <right_val>-0.6053069233894348</right_val></_></_>
+        <_>
+          <!-- tree 24 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  3 0 1 2 -1.</_>
+                <_>
+                  3 0 1 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-6.2055507441982627e-005</threshold>
+            <left_val>0.1300161927938461</left_val>
+            <right_val>-0.1974872946739197</right_val></_></_>
+        <_>
+          <!-- tree 25 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 8 1 2 -1.</_>
+                <_>
+                  12 9 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-6.3192099332809448e-004</threshold>
+            <left_val>0.1096692979335785</left_val>
+            <right_val>-0.2504112124443054</right_val></_></_>
+        <_>
+          <!-- tree 26 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 7 1 2 -1.</_>
+                <_>
+                  2 7 1 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>4.8459400422871113e-003</threshold>
+            <left_val>0.0365070700645447</left_val>
+            <right_val>-0.6489943265914917</right_val></_></_>
+        <_>
+          <!-- tree 27 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 8 8 2 -1.</_>
+                <_>
+                  14 8 4 1 2.</_>
+                <_>
+                  10 9 4 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0106835700571537</threshold>
+            <left_val>7.8355707228183746e-003</left_val>
+            <right_val>-0.2977747917175293</right_val></_></_>
+        <_>
+          <!-- tree 28 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 8 8 2 -1.</_>
+                <_>
+                  6 8 4 1 2.</_>
+                <_>
+                  10 9 4 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.0145319867879152e-003</threshold>
+            <left_val>-0.0892472267150879</left_val>
+            <right_val>0.2996223866939545</right_val></_></_>
+        <_>
+          <!-- tree 29 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 1 3 1 -1.</_>
+                <_>
+                  16 1 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.8510889494791627e-003</threshold>
+            <left_val>0.0236809290945530</left_val>
+            <right_val>-0.7238103747367859</right_val></_></_>
+        <_>
+          <!-- tree 30 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 7 4 3 -1.</_>
+                <_>
+                  9 8 4 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>4.7355238348245621e-003</threshold>
+            <left_val>-0.0657369196414948</left_val>
+            <right_val>0.3911550045013428</right_val></_></_>
+        <_>
+          <!-- tree 31 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 14 3 1 -1.</_>
+                <_>
+                  23 14 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-7.4494199361652136e-004</threshold>
+            <left_val>-0.4852088987827301</left_val>
+            <right_val>0.0454279705882072</right_val></_></_>
+        <_>
+          <!-- tree 32 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 0 24 6 -1.</_>
+                <_>
+                  0 0 12 3 2.</_>
+                <_>
+                  12 3 12 3 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0627472773194313</threshold>
+            <left_val>0.0500667802989483</left_val>
+            <right_val>-0.4384383857250214</right_val></_></_>
+        <_>
+          <!-- tree 33 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  16 5 9 10 -1.</_>
+                <_>
+                  16 10 9 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.2686055004596710</threshold>
+            <left_val>-0.3205833137035370</left_val>
+            <right_val>9.1798100620508194e-003</right_val></_></_>
+        <_>
+          <!-- tree 34 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 5 24 10 -1.</_>
+                <_>
+                  0 5 12 5 2.</_>
+                <_>
+                  12 10 12 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0852702632546425</threshold>
+            <left_val>0.0554314814507961</left_val>
+            <right_val>-0.4401814043521881</right_val></_></_>
+        <_>
+          <!-- tree 35 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 0 3 3 -1.</_>
+                <_>
+                  19 0 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.2441238872706890e-003</threshold>
+            <left_val>-0.5971152782440186</left_val>
+            <right_val>0.0221458300948143</right_val></_></_>
+        <_>
+          <!-- tree 36 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 0 5 3 -1.</_>
+                <_>
+                  0 1 5 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>9.7475049551576376e-004</threshold>
+            <left_val>-0.1235596016049385</left_val>
+            <right_val>0.1907798945903778</right_val></_></_>
+        <_>
+          <!-- tree 37 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 0 3 3 -1.</_>
+                <_>
+                  19 0 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.5493249015416950e-005</threshold>
+            <left_val>0.1455056071281433</left_val>
+            <right_val>-0.1660809069871903</right_val></_></_>
+        <_>
+          <!-- tree 38 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 0 3 3 -1.</_>
+                <_>
+                  5 0 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.9346049521118402e-003</threshold>
+            <left_val>-0.4977537989616394</left_val>
+            <right_val>0.0467028282582760</right_val></_></_>
+        <_>
+          <!-- tree 39 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 4 3 4 -1.</_>
+                <_>
+                  21 4 1 4 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-2.0600769203156233e-003</threshold>
+            <left_val>0.3115827143192291</left_val>
+            <right_val>-0.1136955991387367</right_val></_></_>
+        <_>
+          <!-- tree 40 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 14 3 1 -1.</_>
+                <_>
+                  1 14 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.7839051219634712e-004</threshold>
+            <left_val>-0.3698039948940277</left_val>
+            <right_val>0.0645661503076553</right_val></_></_>
+        <_>
+          <!-- tree 41 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 14 3 1 -1.</_>
+                <_>
+                  21 14 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>5.1422958495095372e-004</threshold>
+            <left_val>-0.0961819887161255</left_val>
+            <right_val>0.3009288907051086</right_val></_></_>
+        <_>
+          <!-- tree 42 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  3 0 15 6 -1.</_>
+                <_>
+                  8 0 5 6 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0784983485937119</threshold>
+            <left_val>-0.0689302086830139</left_val>
+            <right_val>0.3127259910106659</right_val></_></_>
+        <_>
+          <!-- tree 43 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 0 6 12 -1.</_>
+                <_>
+                  10 0 3 12 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0450616702437401</threshold>
+            <left_val>0.2241975069046021</left_val>
+            <right_val>-0.1656804978847504</right_val></_></_>
+        <_>
+          <!-- tree 44 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 0 10 1 -1.</_>
+                <_>
+                  10 0 5 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0423259809613228</threshold>
+            <left_val>-0.0672995299100876</left_val>
+            <right_val>0.3668734133243561</right_val></_></_>
+        <_>
+          <!-- tree 45 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 3 2 1 -1.</_>
+                <_>
+                  15 3 1 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-5.8943959884345531e-003</threshold>
+            <left_val>-0.5873826742172241</left_val>
+            <right_val>0.0135876899585128</right_val></_></_>
+        <_>
+          <!-- tree 46 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 3 1 2 -1.</_>
+                <_>
+                  10 3 1 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>3.5844470839947462e-003</threshold>
+            <left_val>0.0429209694266319</left_val>
+            <right_val>-0.5582286119461060</right_val></_></_>
+        <_>
+          <!-- tree 47 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 14 3 1 -1.</_>
+                <_>
+                  21 14 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.6874058898538351e-004</threshold>
+            <left_val>0.3111866116523743</left_val>
+            <right_val>-0.1252097934484482</right_val></_></_>
+        <_>
+          <!-- tree 48 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 1 6 14 -1.</_>
+                <_>
+                  0 8 6 7 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.1287658959627152</threshold>
+            <left_val>0.0332484208047390</left_val>
+            <right_val>-0.7489097118377686</right_val></_></_>
+        <_>
+          <!-- tree 49 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 1 5 4 -1.</_>
+                <_>
+                  19 2 5 2 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0281043201684952</threshold>
+            <left_val>-0.0612223185598850</left_val>
+            <right_val>0.5541793107986450</right_val></_></_>
+        <_>
+          <!-- tree 50 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 13 14 2 -1.</_>
+                <_>
+                  0 13 7 1 2.</_>
+                <_>
+                  7 14 7 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.1645349916070700e-003</threshold>
+            <left_val>-0.1380790024995804</left_val>
+            <right_val>0.1662399023771286</right_val></_></_>
+        <_>
+          <!-- tree 51 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 13 13 2 -1.</_>
+                <_>
+                  6 14 13 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0231572296470404</threshold>
+            <left_val>0.5367324948310852</left_val>
+            <right_val>-0.0466714315116405</right_val></_></_>
+        <_>
+          <!-- tree 52 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 11 3 1 -1.</_>
+                <_>
+                  12 11 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-9.1285107191652060e-004</threshold>
+            <left_val>-0.5669928193092346</left_val>
+            <right_val>0.0452644899487495</right_val></_></_>
+        <_>
+          <!-- tree 53 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 14 3 1 -1.</_>
+                <_>
+                  21 14 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>9.8842545412480831e-004</threshold>
+            <left_val>-0.0404734499752522</left_val>
+            <right_val>0.2385493069887161</right_val></_></_>
+        <_>
+          <!-- tree 54 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 0 3 1 -1.</_>
+                <_>
+                  1 0 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.9869727808982134e-004</threshold>
+            <left_val>-0.4527383148670197</left_val>
+            <right_val>0.0506268702447414</right_val></_></_>
+        <_>
+          <!-- tree 55 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 4 3 7 -1.</_>
+                <_>
+                  21 4 1 7 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.2696399614214897e-003</threshold>
+            <left_val>-0.0401576496660709</left_val>
+            <right_val>0.2442702949047089</right_val></_></_>
+        <_>
+          <!-- tree 56 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 10 3 5 -1.</_>
+                <_>
+                  5 10 1 5 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.8787750527262688e-003</threshold>
+            <left_val>0.0300434697419405</left_val>
+            <right_val>-0.7466397881507874</right_val></_></_>
+        <_>
+          <!-- tree 57 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 4 3 7 -1.</_>
+                <_>
+                  21 4 1 7 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.7493149498477578e-003</threshold>
+            <left_val>0.1271470040082932</left_val>
+            <right_val>-0.0932326316833496</right_val></_></_>
+        <_>
+          <!-- tree 58 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 4 3 7 -1.</_>
+                <_>
+                  3 4 1 7 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.2234091088175774e-003</threshold>
+            <left_val>0.3654603958129883</left_val>
+            <right_val>-0.0614285804331303</right_val></_></_>
+        <_>
+          <!-- tree 59 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 7 3 2 -1.</_>
+                <_>
+                  21 7 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>9.2927180230617523e-004</threshold>
+            <left_val>-0.0713636279106140</left_val>
+            <right_val>0.2179177999496460</right_val></_></_>
+        <_>
+          <!-- tree 60 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 6 3 3 -1.</_>
+                <_>
+                  3 6 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.0375359561294317e-003</threshold>
+            <left_val>-0.1004671007394791</left_val>
+            <right_val>0.2456530034542084</right_val></_></_>
+        <_>
+          <!-- tree 61 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 3 2 1 -1.</_>
+                <_>
+                  15 3 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.1646949462592602e-003</threshold>
+            <left_val>0.0172448493540287</left_val>
+            <right_val>-0.5401142835617065</right_val></_></_>
+        <_>
+          <!-- tree 62 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 3 2 1 -1.</_>
+                <_>
+                  9 3 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.1731549572432414e-005</threshold>
+            <left_val>-0.2231516987085342</left_val>
+            <right_val>0.1120041981339455</right_val></_></_>
+        <_>
+          <!-- tree 63 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 0 3 2 -1.</_>
+                <_>
+                  23 0 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>7.6199648901820183e-004</threshold>
+            <left_val>0.0709937065839767</left_val>
+            <right_val>-0.4514509141445160</right_val></_></_>
+        <_>
+          <!-- tree 64 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 3 9 1 -1.</_>
+                <_>
+                  14 6 3 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0533643886446953</threshold>
+            <left_val>-0.0513495318591595</left_val>
+            <right_val>0.4850079119205475</right_val></_></_>
+        <_>
+          <!-- tree 65 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 0 3 2 -1.</_>
+                <_>
+                  23 0 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-8.8065088493749499e-004</threshold>
+            <left_val>-0.4615975916385651</left_val>
+            <right_val>0.0786927118897438</right_val></_></_>
+        <_>
+          <!-- tree 66 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 0 3 2 -1.</_>
+                <_>
+                  1 0 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.1948919855058193e-003</threshold>
+            <left_val>0.0406531207263470</left_val>
+            <right_val>-0.5097315907478333</right_val></_></_>
+        <_>
+          <!-- tree 67 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  19 0 5 3 -1.</_>
+                <_>
+                  18 1 5 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-7.7654779888689518e-003</threshold>
+            <left_val>0.1959609985351563</left_val>
+            <right_val>-0.0437754206359386</right_val></_></_>
+        <_>
+          <!-- tree 68 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 0 3 5 -1.</_>
+                <_>
+                  7 1 1 5 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>9.3912240117788315e-003</threshold>
+            <left_val>-0.0567242205142975</left_val>
+            <right_val>0.3725278973579407</right_val></_></_></trees>
+      <stage_threshold>-1.3205020427703857</stage_threshold>
+      <parent>10</parent>
+      <next>-1</next></_>
+    <_>
+      <!-- stage 12 -->
+      <trees>
+        <_>
+          <!-- tree 0 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 4 15 6 -1.</_>
+                <_>
+                  5 6 15 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0451972298324108</threshold>
+            <left_val>-0.3295538127422333</left_val>
+            <right_val>0.2990162074565888</right_val></_></_>
+        <_>
+          <!-- tree 1 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 9 2 2 -1.</_>
+                <_>
+                  14 9 1 1 2.</_>
+                <_>
+                  13 10 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.3553559547290206e-003</threshold>
+            <left_val>-0.0175733491778374</left_val>
+            <right_val>0.3125779032707214</right_val></_></_>
+        <_>
+          <!-- tree 2 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 9 2 2 -1.</_>
+                <_>
+                  10 9 1 1 2.</_>
+                <_>
+                  11 10 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.1965299490839243e-003</threshold>
+            <left_val>0.5199952125549316</left_val>
+            <right_val>-0.0838108435273170</right_val></_></_>
+        <_>
+          <!-- tree 3 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  9 0 10 1 -1.</_>
+                <_>
+                  9 0 5 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-9.8423175513744354e-003</threshold>
+            <left_val>0.1452230960130692</left_val>
+            <right_val>-0.0657595172524452</right_val></_></_>
+        <_>
+          <!-- tree 4 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 0 15 1 -1.</_>
+                <_>
+                  10 0 5 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0116844400763512</threshold>
+            <left_val>-0.1969729959964752</left_val>
+            <right_val>0.2236510962247849</right_val></_></_>
+        <_>
+          <!-- tree 5 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 14 3 1 -1.</_>
+                <_>
+                  19 14 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>6.5535708563402295e-004</threshold>
+            <left_val>0.0924294590950012</left_val>
+            <right_val>-0.4192915856838226</right_val></_></_>
+        <_>
+          <!-- tree 6 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 9 2 2 -1.</_>
+                <_>
+                  10 9 1 1 2.</_>
+                <_>
+                  11 10 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>7.6187832746654749e-004</threshold>
+            <left_val>-0.1179262995719910</left_val>
+            <right_val>0.4625388979911804</right_val></_></_>
+        <_>
+          <!-- tree 7 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 14 3 1 -1.</_>
+                <_>
+                  19 14 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.8883602721616626e-004</threshold>
+            <left_val>-0.3141990005970001</left_val>
+            <right_val>0.1122139990329742</right_val></_></_>
+        <_>
+          <!-- tree 8 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 14 3 1 -1.</_>
+                <_>
+                  5 14 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.6528389793820679e-004</threshold>
+            <left_val>0.0637587085366249</left_val>
+            <right_val>-0.4968430995941162</right_val></_></_>
+        <_>
+          <!-- tree 9 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 6 3 8 -1.</_>
+                <_>
+                  16 6 1 8 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-2.8825278859585524e-003</threshold>
+            <left_val>-0.5643301010131836</left_val>
+            <right_val>0.0802897736430168</right_val></_></_>
+        <_>
+          <!-- tree 10 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 10 2 2 -1.</_>
+                <_>
+                  10 10 1 1 2.</_>
+                <_>
+                  11 11 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.1837530182674527e-003</threshold>
+            <left_val>0.4873589873313904</left_val>
+            <right_val>-0.0869930088520050</right_val></_></_>
+        <_>
+          <!-- tree 11 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 13 3 2 -1.</_>
+                <_>
+                  23 13 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.0754580143839121e-003</threshold>
+            <left_val>0.0685839131474495</left_val>
+            <right_val>-0.5327677726745606</right_val></_></_>
+        <_>
+          <!-- tree 12 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 13 3 2 -1.</_>
+                <_>
+                  7 14 3 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0384632498025894</threshold>
+            <left_val>-6.1817769892513752e-003</left_val>
+            <right_val>-4.9654257812500000e+003</right_val></_></_>
+        <_>
+          <!-- tree 13 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  16 8 3 3 -1.</_>
+                <_>
+                  16 9 3 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.3636731095612049e-003</threshold>
+            <left_val>-0.0533501282334328</left_val>
+            <right_val>0.3284716904163361</right_val></_></_>
+        <_>
+          <!-- tree 14 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  1 3 20 10 -1.</_>
+                <_>
+                  1 3 10 5 2.</_>
+                <_>
+                  11 8 10 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0303417704999447</threshold>
+            <left_val>0.1171011999249458</left_val>
+            <right_val>-0.3055073022842407</right_val></_></_>
+        <_>
+          <!-- tree 15 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  24 2 1 10 -1.</_>
+                <_>
+                  24 2 1 5 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>9.7897462546825409e-003</threshold>
+            <left_val>-0.1015743985772133</left_val>
+            <right_val>0.0459811389446259</right_val></_></_>
+        <_>
+          <!-- tree 16 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 13 3 2 -1.</_>
+                <_>
+                  1 13 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>9.7776507027447224e-004</threshold>
+            <left_val>0.0687318369746208</left_val>
+            <right_val>-0.4764721989631653</right_val></_></_>
+        <_>
+          <!-- tree 17 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  16 8 3 3 -1.</_>
+                <_>
+                  16 9 3 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-2.8879200108349323e-003</threshold>
+            <left_val>0.1556992977857590</left_val>
+            <right_val>-0.0954236164689064</right_val></_></_>
+        <_>
+          <!-- tree 18 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 8 3 3 -1.</_>
+                <_>
+                  6 9 3 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.1463249363005161e-003</threshold>
+            <left_val>-0.0721410065889359</left_val>
+            <right_val>0.4527336061000824</right_val></_></_>
+        <_>
+          <!-- tree 19 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 4 3 11 -1.</_>
+                <_>
+                  16 4 1 11 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>8.3185704424977303e-003</threshold>
+            <left_val>0.0334858298301697</left_val>
+            <right_val>-0.6029986739158630</right_val></_></_>
+        <_>
+          <!-- tree 20 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 7 15 7 -1.</_>
+                <_>
+                  5 7 5 7 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0467883795499802</threshold>
+            <left_val>0.1435178071260452</left_val>
+            <right_val>-0.2290748953819275</right_val></_></_>
+        <_>
+          <!-- tree 21 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 0 12 6 -1.</_>
+                <_>
+                  10 3 12 3 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0363954007625580</threshold>
+            <left_val>-0.4305442869663239</left_val>
+            <right_val>0.0391317494213581</right_val></_></_>
+        <_>
+          <!-- tree 22 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 0 3 5 -1.</_>
+                <_>
+                  5 0 1 5 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.5751320170238614e-003</threshold>
+            <left_val>0.0607377290725708</left_val>
+            <right_val>-0.4951879978179932</right_val></_></_>
+        <_>
+          <!-- tree 23 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 7 3 1 -1.</_>
+                <_>
+                  21 7 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.1553249787539244e-003</threshold>
+            <left_val>-0.0617646090686321</left_val>
+            <right_val>0.3752625882625580</right_val></_></_>
+        <_>
+          <!-- tree 24 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 0 24 8 -1.</_>
+                <_>
+                  0 0 12 4 2.</_>
+                <_>
+                  12 4 12 4 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.1234842985868454</threshold>
+            <left_val>0.0500512793660164</left_val>
+            <right_val>-0.6027358770370483</right_val></_></_>
+        <_>
+          <!-- tree 25 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 7 3 1 -1.</_>
+                <_>
+                  21 7 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.0553579777479172e-003</threshold>
+            <left_val>0.3167768120765686</left_val>
+            <right_val>-0.0818392634391785</right_val></_></_>
+        <_>
+          <!-- tree 26 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 7 3 1 -1.</_>
+                <_>
+                  3 7 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-9.7458128584548831e-004</threshold>
+            <left_val>0.3963795006275177</left_val>
+            <right_val>-0.0752126276493073</right_val></_></_>
+        <_>
+          <!-- tree 27 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 10 3 4 -1.</_>
+                <_>
+                  23 10 1 4 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.3001420302316546e-003</threshold>
+            <left_val>-0.4923982024192810</left_val>
+            <right_val>0.0698127076029778</right_val></_></_>
+        <_>
+          <!-- tree 28 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 10 3 4 -1.</_>
+                <_>
+                  1 10 1 4 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.0015110019594431e-003</threshold>
+            <left_val>-0.4479283094406128</left_val>
+            <right_val>0.0578389503061771</right_val></_></_>
+        <_>
+          <!-- tree 29 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 12 15 3 -1.</_>
+                <_>
+                  5 13 15 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0214937906712294</threshold>
+            <left_val>0.5958725214004517</left_val>
+            <right_val>-0.0523720681667328</right_val></_></_>
+        <_>
+          <!-- tree 30 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 11 3 1 -1.</_>
+                <_>
+                  1 11 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.1285119368694723e-004</threshold>
+            <left_val>0.0927291736006737</left_val>
+            <right_val>-0.3207465112209320</right_val></_></_>
+        <_>
+          <!-- tree 31 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 8 3 1 -1.</_>
+                <_>
+                  21 8 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.4167060144245625e-003</threshold>
+            <left_val>-0.0471179410815239</left_val>
+            <right_val>0.3823896944522858</right_val></_></_>
+        <_>
+          <!-- tree 32 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 8 3 1 -1.</_>
+                <_>
+                  3 8 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>8.9678127551451325e-004</threshold>
+            <left_val>-0.0784078985452652</left_val>
+            <right_val>0.3607592880725861</right_val></_></_>
+        <_>
+          <!-- tree 33 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 7 2 2 -1.</_>
+                <_>
+                  21 7 1 1 2.</_>
+                <_>
+                  20 8 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>5.6262069847434759e-004</threshold>
+            <left_val>-0.0705354586243629</left_val>
+            <right_val>0.3716919124126434</right_val></_></_>
+        <_>
+          <!-- tree 34 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  3 7 2 2 -1.</_>
+                <_>
+                  3 7 1 1 2.</_>
+                <_>
+                  4 8 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.9128587124869227e-004</threshold>
+            <left_val>-0.0784324482083321</left_val>
+            <right_val>0.3491294085979462</right_val></_></_>
+        <_>
+          <!-- tree 35 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 10 3 4 -1.</_>
+                <_>
+                  12 10 1 4 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.7877599457278848e-003</threshold>
+            <left_val>0.0787876099348068</left_val>
+            <right_val>-0.3884367942810059</right_val></_></_>
+        <_>
+          <!-- tree 36 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 1 3 14 -1.</_>
+                <_>
+                  9 1 1 14 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.0873321704566479e-003</threshold>
+            <left_val>0.0530074611306190</left_val>
+            <right_val>-0.5423653721809387</right_val></_></_>
+        <_>
+          <!-- tree 37 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 0 18 9 -1.</_>
+                <_>
+                  4 0 9 9 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.3047750890254974</threshold>
+            <left_val>-0.0496183000504971</left_val>
+            <right_val>0.6538562774658203</right_val></_></_>
+        <_>
+          <!-- tree 38 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 0 1 2 -1.</_>
+                <_>
+                  12 0 1 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>4.6278488298412412e-005</threshold>
+            <left_val>-0.2570258080959320</left_val>
+            <right_val>0.1156508028507233</right_val></_></_>
+        <_>
+          <!-- tree 39 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 7 9 8 -1.</_>
+                <_>
+                  12 9 9 4 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0273665301501751</threshold>
+            <left_val>0.0894302725791931</left_val>
+            <right_val>-0.2073701024055481</right_val></_></_>
+        <_>
+          <!-- tree 40 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 13 15 2 -1.</_>
+                <_>
+                  5 14 15 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0181142799556255</threshold>
+            <left_val>0.5061715245246887</left_val>
+            <right_val>-0.0541042312979698</right_val></_></_>
+        <_>
+          <!-- tree 41 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  16 1 6 8 -1.</_>
+                <_>
+                  16 5 6 4 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0933904424309731</threshold>
+            <left_val>0.0176323894411325</left_val>
+            <right_val>-0.4041165113449097</right_val></_></_>
+        <_>
+          <!-- tree 42 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 1 3 2 -1.</_>
+                <_>
+                  1 1 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-5.9651897754520178e-004</threshold>
+            <left_val>-0.4152236878871918</left_val>
+            <right_val>0.0601581409573555</right_val></_></_>
+        <_>
+          <!-- tree 43 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 12 2 2 -1.</_>
+                <_>
+                  14 12 1 1 2.</_>
+                <_>
+                  13 13 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-5.9911969583481550e-004</threshold>
+            <left_val>0.1607592999935150</left_val>
+            <right_val>-0.0346959605813026</right_val></_></_>
+        <_>
+          <!-- tree 44 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  3 7 9 8 -1.</_>
+                <_>
+                  3 9 9 4 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0191322006285191</threshold>
+            <left_val>0.1261409074068070</left_val>
+            <right_val>-0.2019957005977631</right_val></_></_>
+        <_>
+          <!-- tree 45 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  14 9 7 3 -1.</_>
+                <_>
+                  14 10 7 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.4587599113583565e-003</threshold>
+            <left_val>-0.0626959577202797</left_val>
+            <right_val>0.3163996934890747</right_val></_></_>
+        <_>
+          <!-- tree 46 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 1 4 8 -1.</_>
+                <_>
+                  4 5 4 4 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0247909203171730</threshold>
+            <left_val>0.0600935593247414</left_val>
+            <right_val>-0.4698452055454254</right_val></_></_>
+        <_>
+          <!-- tree 47 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 3 1 3 -1.</_>
+                <_>
+                  21 4 1 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>1.5529870288446546e-003</threshold>
+            <left_val>-0.0416915491223335</left_val>
+            <right_val>0.0999688506126404</right_val></_></_>
+        <_>
+          <!-- tree 48 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  3 3 3 1 -1.</_>
+                <_>
+                  4 4 1 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-2.5789639912545681e-003</threshold>
+            <left_val>0.3771735131740570</left_val>
+            <right_val>-0.0821809917688370</right_val></_></_>
+        <_>
+          <!-- tree 49 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 1 3 1 -1.</_>
+                <_>
+                  23 1 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>6.4771092729642987e-004</threshold>
+            <left_val>0.0417168214917183</left_val>
+            <right_val>-0.4829668104648590</right_val></_></_>
+        <_>
+          <!-- tree 50 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  3 0 11 6 -1.</_>
+                <_>
+                  3 3 11 3 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0424816496670246</threshold>
+            <left_val>-0.6040111184120178</left_val>
+            <right_val>0.0423785299062729</right_val></_></_>
+        <_>
+          <!-- tree 51 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  9 5 7 4 -1.</_>
+                <_>
+                  9 7 7 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0134918596595526</threshold>
+            <left_val>-0.0647340118885040</left_val>
+            <right_val>0.4287011027336121</right_val></_></_>
+        <_>
+          <!-- tree 52 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 1 3 1 -1.</_>
+                <_>
+                  1 1 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>5.0020369235426188e-004</threshold>
+            <left_val>0.0654933378100395</left_val>
+            <right_val>-0.4458478987216950</right_val></_></_>
+        <_>
+          <!-- tree 53 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  1 7 24 8 -1.</_>
+                <_>
+                  13 7 12 4 2.</_>
+                <_>
+                  1 11 12 4 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.1838033944368362</threshold>
+            <left_val>0.0417398586869240</left_val>
+            <right_val>-0.6594216227531433</right_val></_></_>
+        <_>
+          <!-- tree 54 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 6 6 3 -1.</_>
+                <_>
+                  14 8 2 3 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-0.0487621799111366</threshold>
+            <left_val>-0.3839060068130493</left_val>
+            <right_val>0.0584038607776165</right_val></_></_>
+        <_>
+          <!-- tree 55 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 8 3 2 -1.</_>
+                <_>
+                  12 8 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.6553630121052265e-003</threshold>
+            <left_val>0.0536402389407158</left_val>
+            <right_val>-0.4118762910366058</right_val></_></_>
+        <_>
+          <!-- tree 56 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 10 1 2 -1.</_>
+                <_>
+                  11 10 1 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-4.8329820856451988e-004</threshold>
+            <left_val>0.1706711947917938</left_val>
+            <right_val>-0.1491951048374176</right_val></_></_></trees>
+      <stage_threshold>-1.2912670373916626</stage_threshold>
+      <parent>11</parent>
+      <next>-1</next></_>
+    <_>
+      <!-- stage 13 -->
+      <trees>
+        <_>
+          <!-- tree 0 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 7 15 6 -1.</_>
+                <_>
+                  5 9 15 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0928201302886009</threshold>
+            <left_val>0.3223660886287689</left_val>
+            <right_val>-0.2023689001798630</right_val></_></_>
+        <_>
+          <!-- tree 1 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 0 8 10 -1.</_>
+                <_>
+                  11 0 4 10 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0813586935400963</threshold>
+            <left_val>-0.0594612397253513</left_val>
+            <right_val>0.2730144858360291</right_val></_></_>
+        <_>
+          <!-- tree 2 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 0 10 8 -1.</_>
+                <_>
+                  11 0 5 8 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0678004473447800</threshold>
+            <left_val>-0.2987042069435120</left_val>
+            <right_val>0.1908088028430939</right_val></_></_>
+        <_>
+          <!-- tree 3 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  17 9 1 3 -1.</_>
+                <_>
+                  17 10 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.6141489613801241e-003</threshold>
+            <left_val>-0.0506333410739899</left_val>
+            <right_val>0.4730246961116791</right_val></_></_>
+        <_>
+          <!-- tree 4 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 9 3 3 -1.</_>
+                <_>
+                  13 10 1 3 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0507884509861469</threshold>
+            <left_val>3.4009190276265144e-003</left_val>
+            <right_val>-4.8761440429687500e+003</right_val></_></_>
+        <_>
+          <!-- tree 5 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  24 1 1 12 -1.</_>
+                <_>
+                  24 1 1 6 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-0.0722965672612190</threshold>
+            <left_val>-0.3951897919178009</left_val>
+            <right_val>5.1946029998362064e-003</right_val></_></_>
+        <_>
+          <!-- tree 6 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 7 1 3 -1.</_>
+                <_>
+                  7 8 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.8506350461393595e-003</threshold>
+            <left_val>-0.0791095569729805</left_val>
+            <right_val>0.4381273984909058</right_val></_></_>
+        <_>
+          <!-- tree 7 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  16 7 3 3 -1.</_>
+                <_>
+                  17 8 1 1 9.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.8955479394644499e-003</threshold>
+            <left_val>-0.0773860514163971</left_val>
+            <right_val>0.2460761964321137</right_val></_></_>
+        <_>
+          <!-- tree 8 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 0 14 9 -1.</_>
+                <_>
+                  2 3 14 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.4614686071872711</threshold>
+            <left_val>0.0376065298914909</left_val>
+            <right_val>-2.4518649902343750e+003</right_val></_></_>
+        <_>
+          <!-- tree 9 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  24 1 1 12 -1.</_>
+                <_>
+                  24 1 1 6 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0279431398957968</threshold>
+            <left_val>-0.0671835467219353</left_val>
+            <right_val>0.0458649098873138</right_val></_></_>
+        <_>
+          <!-- tree 10 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 7 3 3 -1.</_>
+                <_>
+                  7 8 1 1 9.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-9.6679981797933578e-003</threshold>
+            <left_val>0.5131018757820129</left_val>
+            <right_val>-0.0659519731998444</right_val></_></_>
+        <_>
+          <!-- tree 11 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 9 3 6 -1.</_>
+                <_>
+                  12 9 1 6 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.4609879581257701e-003</threshold>
+            <left_val>-0.4582315087318420</left_val>
+            <right_val>0.0807310566306114</right_val></_></_>
+        <_>
+          <!-- tree 12 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 12 3 3 -1.</_>
+                <_>
+                  5 12 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.2706810375675559e-003</threshold>
+            <left_val>-0.4739617109298706</left_val>
+            <right_val>0.0654811114072800</right_val></_></_>
+        <_>
+          <!-- tree 13 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 8 1 4 -1.</_>
+                <_>
+                  12 10 1 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-2.0724469795823097e-003</threshold>
+            <left_val>0.1173579990863800</left_val>
+            <right_val>-0.2651118040084839</right_val></_></_>
+        <_>
+          <!-- tree 14 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 11 3 3 -1.</_>
+                <_>
+                  5 11 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.3620340032503009e-003</threshold>
+            <left_val>0.0668927580118179</left_val>
+            <right_val>-0.4975585937500000</right_val></_></_>
+        <_>
+          <!-- tree 15 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  14 9 5 3 -1.</_>
+                <_>
+                  14 10 5 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0182015206664801</threshold>
+            <left_val>0.2193337976932526</left_val>
+            <right_val>-0.0228407997637987</right_val></_></_>
+        <_>
+          <!-- tree 16 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 9 3 3 -1.</_>
+                <_>
+                  8 10 3 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.9590938724577427e-003</threshold>
+            <left_val>-0.0554565489292145</left_val>
+            <right_val>0.5445442199707031</right_val></_></_>
+        <_>
+          <!-- tree 17 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 14 3 1 -1.</_>
+                <_>
+                  23 14 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.7430579434148967e-004</threshold>
+            <left_val>-0.4044311046600342</left_val>
+            <right_val>0.0614488795399666</right_val></_></_>
+        <_>
+          <!-- tree 18 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 5 2 1 -1.</_>
+                <_>
+                  1 5 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.6171150491572917e-005</threshold>
+            <left_val>0.1514282971620560</left_val>
+            <right_val>-0.1908773928880692</right_val></_></_>
+        <_>
+          <!-- tree 19 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 0 7 2 -1.</_>
+                <_>
+                  12 1 7 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>7.4011050164699554e-003</threshold>
+            <left_val>0.0302806701511145</left_val>
+            <right_val>-0.4435423016548157</right_val></_></_>
+        <_>
+          <!-- tree 20 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 0 12 2 -1.</_>
+                <_>
+                  5 1 12 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-6.1939638108015060e-003</threshold>
+            <left_val>-0.5124183297157288</left_val>
+            <right_val>0.0576316006481647</right_val></_></_>
+        <_>
+          <!-- tree 21 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 9 2 2 -1.</_>
+                <_>
+                  14 9 1 1 2.</_>
+                <_>
+                  13 10 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.5711110318079591e-003</threshold>
+            <left_val>0.3601556122303009</left_val>
+            <right_val>-0.0157597493380308</right_val></_></_>
+        <_>
+          <!-- tree 22 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 9 2 2 -1.</_>
+                <_>
+                  10 9 1 1 2.</_>
+                <_>
+                  11 10 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>9.8455836996436119e-004</threshold>
+            <left_val>-0.0595211386680603</left_val>
+            <right_val>0.4729141891002655</right_val></_></_>
+        <_>
+          <!-- tree 23 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 13 3 2 -1.</_>
+                <_>
+                  23 13 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>6.6682987380772829e-004</threshold>
+            <left_val>0.0860610380768776</left_val>
+            <right_val>-0.3736714124679565</right_val></_></_>
+        <_>
+          <!-- tree 24 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 0 3 12 -1.</_>
+                <_>
+                  9 3 3 6 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0269774403423071</threshold>
+            <left_val>0.0606142282485962</left_val>
+            <right_val>-0.4320910871028900</right_val></_></_>
+        <_>
+          <!-- tree 25 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 1 7 10 -1.</_>
+                <_>
+                  18 6 7 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.1486686021089554</threshold>
+            <left_val>-0.3438571095466614</left_val>
+            <right_val>0.0425512716174126</right_val></_></_>
+        <_>
+          <!-- tree 26 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  1 9 22 1 -1.</_>
+                <_>
+                  12 9 11 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0419045910239220</threshold>
+            <left_val>0.0825562030076981</left_val>
+            <right_val>-0.3843984901905060</right_val></_></_>
+        <_>
+          <!-- tree 27 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 4 3 2 -1.</_>
+                <_>
+                  12 4 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.8454530509188771e-003</threshold>
+            <left_val>0.0391631685197353</left_val>
+            <right_val>-0.6076923012733460</right_val></_></_>
+        <_>
+          <!-- tree 28 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 1 7 10 -1.</_>
+                <_>
+                  0 6 7 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.1269188970327377</threshold>
+            <left_val>-0.5400621294975281</left_val>
+            <right_val>0.0443591512739658</right_val></_></_>
+        <_>
+          <!-- tree 29 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 1 5 14 -1.</_>
+                <_>
+                  20 8 5 7 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.1352120041847229</threshold>
+            <left_val>-0.2491877973079681</left_val>
+            <right_val>0.0643676370382309</right_val></_></_>
+        <_>
+          <!-- tree 30 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 1 5 14 -1.</_>
+                <_>
+                  0 8 5 7 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0299009606242180</threshold>
+            <left_val>0.0848273932933807</left_val>
+            <right_val>-0.4113943874835968</right_val></_></_>
+        <_>
+          <!-- tree 31 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  19 0 2 13 -1.</_>
+                <_>
+                  19 0 1 13 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-0.0402889698743820</threshold>
+            <left_val>-0.8389198780059815</left_val>
+            <right_val>3.4967809915542603e-003</right_val></_></_>
+        <_>
+          <!-- tree 32 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 0 13 2 -1.</_>
+                <_>
+                  6 0 13 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>5.9111979790031910e-003</threshold>
+            <left_val>-0.2801533937454224</left_val>
+            <right_val>0.0898688063025475</right_val></_></_>
+        <_>
+          <!-- tree 33 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  14 10 4 3 -1.</_>
+                <_>
+                  14 11 4 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.2559810206294060e-003</threshold>
+            <left_val>-0.0516625083982944</left_val>
+            <right_val>0.2538262009620667</right_val></_></_>
+        <_>
+          <!-- tree 34 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 14 3 1 -1.</_>
+                <_>
+                  1 14 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-5.1295681623741984e-004</threshold>
+            <left_val>-0.4950773119926453</left_val>
+            <right_val>0.0555152595043182</right_val></_></_>
+        <_>
+          <!-- tree 35 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 13 2 2 -1.</_>
+                <_>
+                  14 13 1 1 2.</_>
+                <_>
+                  13 14 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-9.6694158855825663e-004</threshold>
+            <left_val>0.3069371879100800</left_val>
+            <right_val>-0.0283641703426838</right_val></_></_>
+        <_>
+          <!-- tree 36 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 13 2 2 -1.</_>
+                <_>
+                  10 13 1 1 2.</_>
+                <_>
+                  11 14 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>7.7758042607456446e-004</threshold>
+            <left_val>-0.0650922730565071</left_val>
+            <right_val>0.4188047945499420</right_val></_></_>
+        <_>
+          <!-- tree 37 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 13 3 1 -1.</_>
+                <_>
+                  23 13 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-6.2462798086926341e-004</threshold>
+            <left_val>-0.4839457869529724</left_val>
+            <right_val>0.0395184382796288</right_val></_></_>
+        <_>
+          <!-- tree 38 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 3 1 2 -1.</_>
+                <_>
+                  10 3 1 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>2.5175609625875950e-003</threshold>
+            <left_val>0.0650981217622757</left_val>
+            <right_val>-0.3995048999786377</right_val></_></_>
+        <_>
+          <!-- tree 39 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 13 2 2 -1.</_>
+                <_>
+                  14 13 1 1 2.</_>
+                <_>
+                  13 14 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.0349069489166141e-003</threshold>
+            <left_val>-0.0189524590969086</left_val>
+            <right_val>0.2152495980262756</right_val></_></_>
+        <_>
+          <!-- tree 40 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 14 3 1 -1.</_>
+                <_>
+                  12 14 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.0098960483446717e-003</threshold>
+            <left_val>0.0412954017519951</left_val>
+            <right_val>-0.6509199142456055</right_val></_></_>
+        <_>
+          <!-- tree 41 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 13 2 2 -1.</_>
+                <_>
+                  14 13 1 1 2.</_>
+                <_>
+                  13 14 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.1472649172646925e-005</threshold>
+            <left_val>0.0459078997373581</left_val>
+            <right_val>-0.0436094589531422</right_val></_></_>
+        <_>
+          <!-- tree 42 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 13 2 2 -1.</_>
+                <_>
+                  10 13 1 1 2.</_>
+                <_>
+                  11 14 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-8.1048608990386128e-004</threshold>
+            <left_val>0.4110225141048431</left_val>
+            <right_val>-0.0616601109504700</right_val></_></_>
+        <_>
+          <!-- tree 43 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 14 3 1 -1.</_>
+                <_>
+                  23 14 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.1735679581761360e-003</threshold>
+            <left_val>0.0149338804185390</left_val>
+            <right_val>-0.5235828757286072</right_val></_></_>
+        <_>
+          <!-- tree 44 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 14 3 1 -1.</_>
+                <_>
+                  1 14 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.3465310116298497e-004</threshold>
+            <left_val>0.0771246030926704</left_val>
+            <right_val>-0.3294360935688019</right_val></_></_>
+        <_>
+          <!-- tree 45 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  23 0 2 3 -1.</_>
+                <_>
+                  23 1 2 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.5897189732640982e-003</threshold>
+            <left_val>-0.0693358480930328</left_val>
+            <right_val>0.2848043143749237</right_val></_></_>
+        <_>
+          <!-- tree 46 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 1 3 6 -1.</_>
+                <_>
+                  8 1 1 6 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.0630289800465107e-003</threshold>
+            <left_val>0.0490849316120148</left_val>
+            <right_val>-0.5055745244026184</right_val></_></_>
+        <_>
+          <!-- tree 47 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  23 0 2 3 -1.</_>
+                <_>
+                  23 1 2 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-6.5603532129898667e-004</threshold>
+            <left_val>0.1793466955423355</left_val>
+            <right_val>-0.0718848332762718</right_val></_></_>
+        <_>
+          <!-- tree 48 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 7 2 2 -1.</_>
+                <_>
+                  6 7 1 1 2.</_>
+                <_>
+                  7 8 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.2628600234165788e-003</threshold>
+            <left_val>0.4599426984786987</left_val>
+            <right_val>-0.0488579310476780</right_val></_></_>
+        <_>
+          <!-- tree 49 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  17 7 2 2 -1.</_>
+                <_>
+                  18 7 1 1 2.</_>
+                <_>
+                  17 8 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.8222800251096487e-004</threshold>
+            <left_val>-0.0844486132264137</left_val>
+            <right_val>0.3059369921684265</right_val></_></_>
+        <_>
+          <!-- tree 50 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 12 3 2 -1.</_>
+                <_>
+                  8 12 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>8.8345218682661653e-004</threshold>
+            <left_val>0.0652309507131577</left_val>
+            <right_val>-0.3942168056964874</right_val></_></_>
+        <_>
+          <!-- tree 51 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  17 7 2 2 -1.</_>
+                <_>
+                  18 7 1 1 2.</_>
+                <_>
+                  17 8 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.4303219504654408e-003</threshold>
+            <left_val>0.5088474750518799</left_val>
+            <right_val>-0.0379122309386730</right_val></_></_>
+        <_>
+          <!-- tree 52 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 12 3 3 -1.</_>
+                <_>
+                  8 12 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.8830270273610950e-003</threshold>
+            <left_val>-0.4490711987018585</left_val>
+            <right_val>0.0610952600836754</right_val></_></_>
+        <_>
+          <!-- tree 53 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  17 7 2 2 -1.</_>
+                <_>
+                  18 7 1 1 2.</_>
+                <_>
+                  17 8 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.0809300844557583e-004</threshold>
+            <left_val>0.0941019132733345</left_val>
+            <right_val>-0.0420962087810040</right_val></_></_>
+        <_>
+          <!-- tree 54 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 9 20 1 -1.</_>
+                <_>
+                  7 9 10 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0234095193445683</threshold>
+            <left_val>-0.3885976076126099</left_val>
+            <right_val>0.0652604326605797</right_val></_></_>
+        <_>
+          <!-- tree 55 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 2 3 1 -1.</_>
+                <_>
+                  12 2 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-5.0113769248127937e-004</threshold>
+            <left_val>-0.5330324172973633</left_val>
+            <right_val>0.0388857796788216</right_val></_></_>
+        <_>
+          <!-- tree 56 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 7 2 2 -1.</_>
+                <_>
+                  6 7 1 1 2.</_>
+                <_>
+                  7 8 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>5.7018041843548417e-004</threshold>
+            <left_val>-0.0715045183897018</left_val>
+            <right_val>0.3732300996780396</right_val></_></_>
+        <_>
+          <!-- tree 57 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  9 8 12 5 -1.</_>
+                <_>
+                  12 8 6 5 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0396498292684555</threshold>
+            <left_val>-0.4392620027065277</left_val>
+            <right_val>0.0305931698530912</right_val></_></_>
+        <_>
+          <!-- tree 58 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 12 15 2 -1.</_>
+                <_>
+                  5 13 15 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>4.9787419848144054e-003</threshold>
+            <left_val>-0.1653715074062347</left_val>
+            <right_val>0.1449661999940872</right_val></_></_>
+        <_>
+          <!-- tree 59 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  16 10 3 3 -1.</_>
+                <_>
+                  16 11 3 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0123361004516482</threshold>
+            <left_val>0.3429476916790009</left_val>
+            <right_val>-0.0202056393027306</right_val></_></_>
+        <_>
+          <!-- tree 60 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 10 3 3 -1.</_>
+                <_>
+                  6 11 3 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.8023829907178879e-003</threshold>
+            <left_val>-0.0893941223621368</left_val>
+            <right_val>0.2538383007049561</right_val></_></_>
+        <_>
+          <!-- tree 61 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 0 6 9 -1.</_>
+                <_>
+                  13 0 3 9 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-0.1781135052442551</threshold>
+            <left_val>-0.4527376890182495</left_val>
+            <right_val>0.0122753502801061</right_val></_></_>
+        <_>
+          <!-- tree 62 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 0 8 1 -1.</_>
+                <_>
+                  12 0 4 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>6.0157501138746738e-003</threshold>
+            <left_val>-0.1753714978694916</left_val>
+            <right_val>0.1562716960906982</right_val></_></_>
+        <_>
+          <!-- tree 63 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 1 3 1 -1.</_>
+                <_>
+                  16 1 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.3470980338752270e-003</threshold>
+            <left_val>-0.6599810123443604</left_val>
+            <right_val>0.0109351500868797</right_val></_></_>
+        <_>
+          <!-- tree 64 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 1 3 1 -1.</_>
+                <_>
+                  8 1 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-7.2307308437302709e-004</threshold>
+            <left_val>-0.4549460113048554</left_val>
+            <right_val>0.0653259232640266</right_val></_></_>
+        <_>
+          <!-- tree 65 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 0 16 4 -1.</_>
+                <_>
+                  13 0 8 2 2.</_>
+                <_>
+                  5 2 8 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0222205501049757</threshold>
+            <left_val>0.0509401001036167</left_val>
+            <right_val>-0.6069058775901794</right_val></_></_>
+        <_>
+          <!-- tree 66 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 0 1 4 -1.</_>
+                <_>
+                  0 1 1 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>6.2500167405232787e-004</threshold>
+            <left_val>-0.1134081035852432</left_val>
+            <right_val>0.2061399966478348</right_val></_></_>
+        <_>
+          <!-- tree 67 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 3 3 1 -1.</_>
+                <_>
+                  23 3 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-7.8181998105719686e-004</threshold>
+            <left_val>-0.4974359869956970</left_val>
+            <right_val>0.0433999709784985</right_val></_></_>
+        <_>
+          <!-- tree 68 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 0 21 5 -1.</_>
+                <_>
+                  9 0 7 5 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0878828465938568</threshold>
+            <left_val>-0.1508273929357529</left_val>
+            <right_val>0.1590044051408768</right_val></_></_>
+        <_>
+          <!-- tree 69 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 0 20 7 -1.</_>
+                <_>
+                  10 0 10 7 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0284739099442959</threshold>
+            <left_val>-0.2371494024991989</left_val>
+            <right_val>0.0528658702969551</right_val></_></_>
+        <_>
+          <!-- tree 70 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 0 15 8 -1.</_>
+                <_>
+                  10 0 5 8 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0510530881583691</threshold>
+            <left_val>0.4977414011955261</left_val>
+            <right_val>-0.0563456788659096</right_val></_></_></trees>
+      <stage_threshold>-1.2512940168380737</stage_threshold>
+      <parent>12</parent>
+      <next>-1</next></_>
+    <_>
+      <!-- stage 14 -->
+      <trees>
+        <_>
+          <!-- tree 0 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  3 8 12 4 -1.</_>
+                <_>
+                  6 8 6 4 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0161979291588068</threshold>
+            <left_val>0.2120455056428909</left_val>
+            <right_val>-0.3136065900325775</right_val></_></_>
+        <_>
+          <!-- tree 1 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 0 15 12 -1.</_>
+                <_>
+                  10 4 5 4 9.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.4892399013042450</threshold>
+            <left_val>-0.1494351029396057</left_val>
+            <right_val>0.3422046005725861</right_val></_></_>
+        <_>
+          <!-- tree 2 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 2 4 6 -1.</_>
+                <_>
+                  0 5 4 3 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.0836800578981638e-003</threshold>
+            <left_val>0.1864416003227234</left_val>
+            <right_val>-0.2010934948921204</right_val></_></_>
+        <_>
+          <!-- tree 3 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 10 1 3 -1.</_>
+                <_>
+                  12 11 1 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-1.3269910123199224e-003</threshold>
+            <left_val>0.0721661224961281</left_val>
+            <right_val>-0.0546591617166996</right_val></_></_>
+        <_>
+          <!-- tree 4 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 0 3 1 -1.</_>
+                <_>
+                  12 0 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>5.0481579819461331e-005</threshold>
+            <left_val>-0.1771785020828247</left_val>
+            <right_val>0.1855183988809586</right_val></_></_>
+        <_>
+          <!-- tree 5 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 6 3 1 -1.</_>
+                <_>
+                  16 6 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-9.4567041378468275e-004</threshold>
+            <left_val>-0.6284232139587402</left_val>
+            <right_val>0.0432993583381176</right_val></_></_>
+        <_>
+          <!-- tree 6 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 10 1 4 -1.</_>
+                <_>
+                  4 11 1 2 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>7.0139212766662240e-004</threshold>
+            <left_val>-0.1898141056299210</left_val>
+            <right_val>0.1577416956424713</right_val></_></_>
+        <_>
+          <!-- tree 7 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  21 0 4 2 -1.</_>
+                <_>
+                  22 1 2 2 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0108787296339870</threshold>
+            <left_val>0.0322809107601643</left_val>
+            <right_val>-0.6225860118865967</right_val></_></_>
+        <_>
+          <!-- tree 8 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 0 3 6 -1.</_>
+                <_>
+                  4 2 3 2 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0292051602154970</threshold>
+            <left_val>0.0571587495505810</left_val>
+            <right_val>-0.5202301144599915</right_val></_></_>
+        <_>
+          <!-- tree 9 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 10 6 2 -1.</_>
+                <_>
+                  16 10 3 1 2.</_>
+                <_>
+                  13 11 3 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.4313809592276812e-003</threshold>
+            <left_val>0.2243351936340332</left_val>
+            <right_val>-0.0850164815783501</right_val></_></_>
+        <_>
+          <!-- tree 10 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 10 6 2 -1.</_>
+                <_>
+                  6 10 3 1 2.</_>
+                <_>
+                  9 11 3 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.9768159836530685e-003</threshold>
+            <left_val>-0.1128496006131172</left_val>
+            <right_val>0.2773370146751404</right_val></_></_>
+        <_>
+          <!-- tree 11 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 6 3 1 -1.</_>
+                <_>
+                  16 6 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.1810859432443976e-003</threshold>
+            <left_val>0.0536743700504303</left_val>
+            <right_val>-0.5698500871658325</right_val></_></_>
+        <_>
+          <!-- tree 12 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 6 3 1 -1.</_>
+                <_>
+                  8 6 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>9.7088637994602323e-004</threshold>
+            <left_val>0.0325215905904770</left_val>
+            <right_val>-0.7129675745964050</right_val></_></_>
+        <_>
+          <!-- tree 13 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 6 9 2 -1.</_>
+                <_>
+                  8 7 9 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-6.1679352074861526e-003</threshold>
+            <left_val>0.1605381965637207</left_val>
+            <right_val>-0.1658942997455597</right_val></_></_>
+        <_>
+          <!-- tree 14 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 0 16 6 -1.</_>
+                <_>
+                  6 0 8 6 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0674820318818092</threshold>
+            <left_val>0.2918994128704071</left_val>
+            <right_val>-0.1011980995535851</right_val></_></_>
+        <_>
+          <!-- tree 15 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 8 1 2 -1.</_>
+                <_>
+                  13 8 1 1 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>1.9201979739591479e-003</threshold>
+            <left_val>-0.0743943825364113</left_val>
+            <right_val>0.0366074293851852</right_val></_></_>
+        <_>
+          <!-- tree 16 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  3 2 18 13 -1.</_>
+                <_>
+                  12 2 9 13 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.2438479065895081</threshold>
+            <left_val>0.5116614103317261</left_val>
+            <right_val>-0.0660788863897324</right_val></_></_>
+        <_>
+          <!-- tree 17 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  16 7 2 4 -1.</_>
+                <_>
+                  16 7 1 4 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>2.8760021086782217e-004</threshold>
+            <left_val>-0.2453003972768784</left_val>
+            <right_val>0.0764203593134880</right_val></_></_>
+        <_>
+          <!-- tree 18 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 0 8 1 -1.</_>
+                <_>
+                  11 0 4 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.5020390748977661e-003</threshold>
+            <left_val>-0.2682819068431854</left_val>
+            <right_val>0.1056384965777397</right_val></_></_>
+        <_>
+          <!-- tree 19 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 5 3 4 -1.</_>
+                <_>
+                  16 6 1 4 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-0.0252749305218458</threshold>
+            <left_val>-0.5495181083679199</left_val>
+            <right_val>-2.5555680040270090e-003</right_val></_></_>
+        <_>
+          <!-- tree 20 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  8 0 11 4 -1.</_>
+                <_>
+                  8 0 11 2 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.1262724995613098</threshold>
+            <left_val>0.0418892912566662</left_val>
+            <right_val>-0.6237785220146179</right_val></_></_>
+        <_>
+          <!-- tree 21 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 1 3 1 -1.</_>
+                <_>
+                  12 1 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.1379190254956484e-003</threshold>
+            <left_val>0.0298023708164692</left_val>
+            <right_val>-0.6472840905189514</right_val></_></_>
+        <_>
+          <!-- tree 22 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 3 15 3 -1.</_>
+                <_>
+                  5 4 15 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.9023140193894506e-003</threshold>
+            <left_val>0.2144210040569305</left_val>
+            <right_val>-0.1193241029977799</right_val></_></_>
+        <_>
+          <!-- tree 23 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 2 4 3 -1.</_>
+                <_>
+                  19 3 4 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>9.0218838304281235e-003</threshold>
+            <left_val>-0.0770102664828300</left_val>
+            <right_val>0.3349851965904236</right_val></_></_>
+        <_>
+          <!-- tree 24 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 2 3 4 -1.</_>
+                <_>
+                  6 3 1 4 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>6.4549939706921577e-003</threshold>
+            <left_val>-0.0785904973745346</left_val>
+            <right_val>0.3167071044445038</right_val></_></_>
+        <_>
+          <!-- tree 25 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  3 0 20 6 -1.</_>
+                <_>
+                  8 0 10 6 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0544976592063904</threshold>
+            <left_val>-0.2082500010728836</left_val>
+            <right_val>0.1359824985265732</right_val></_></_>
+        <_>
+          <!-- tree 26 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 0 10 4 -1.</_>
+                <_>
+                  6 2 10 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>0.0276991594582796</threshold>
+            <left_val>0.0468346700072289</left_val>
+            <right_val>-0.5784531235694885</right_val></_></_>
+        <_>
+          <!-- tree 27 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 0 4 2 -1.</_>
+                <_>
+                  13 0 2 2 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-5.1538292318582535e-003</threshold>
+            <left_val>0.0768204629421234</left_val>
+            <right_val>-0.0906350016593933</right_val></_></_>
+        <_>
+          <!-- tree 28 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  6 8 3 4 -1.</_>
+                <_>
+                  7 8 1 4 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.8087000353261828e-003</threshold>
+            <left_val>0.2301243990659714</left_val>
+            <right_val>-0.1036864966154099</right_val></_></_>
+        <_>
+          <!-- tree 29 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 0 6 1 -1.</_>
+                <_>
+                  15 2 2 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>0.0205713901668787</threshold>
+            <left_val>0.0157123506069183</left_val>
+            <right_val>-0.4894546866416931</right_val></_></_>
+        <_>
+          <!-- tree 30 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  12 0 1 6 -1.</_>
+                <_>
+                  10 2 1 2 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-0.0120548503473401</threshold>
+            <left_val>-0.4990040063858032</left_val>
+            <right_val>0.0463244915008545</right_val></_></_>
+        <_>
+          <!-- tree 31 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  23 12 2 1 -1.</_>
+                <_>
+                  23 12 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.1540741221979260e-005</threshold>
+            <left_val>0.1572497934103012</left_val>
+            <right_val>-0.1841527968645096</right_val></_></_>
+        <_>
+          <!-- tree 32 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  3 7 2 2 -1.</_>
+                <_>
+                  3 7 1 1 2.</_>
+                <_>
+                  4 8 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.7443990479223430e-004</threshold>
+            <left_val>0.2446262985467911</left_val>
+            <right_val>-0.0874714031815529</right_val></_></_>
+        <_>
+          <!-- tree 33 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 7 2 2 -1.</_>
+                <_>
+                  21 7 1 1 2.</_>
+                <_>
+                  20 8 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-6.8125530378893018e-004</threshold>
+            <left_val>0.2933501005172730</left_val>
+            <right_val>-0.1057249009609222</right_val></_></_>
+        <_>
+          <!-- tree 34 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  3 7 2 2 -1.</_>
+                <_>
+                  3 7 1 1 2.</_>
+                <_>
+                  4 8 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.4781370302662253e-004</threshold>
+            <left_val>-0.1059036031365395</left_val>
+            <right_val>0.2360060065984726</right_val></_></_>
+        <_>
+          <!-- tree 35 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 0 3 13 -1.</_>
+                <_>
+                  19 0 1 13 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.3565799929201603e-003</threshold>
+            <left_val>0.0781406983733177</left_val>
+            <right_val>-0.3778645098209381</right_val></_></_>
+        <_>
+          <!-- tree 36 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 0 3 12 -1.</_>
+                <_>
+                  5 0 1 12 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-7.4149328283965588e-003</threshold>
+            <left_val>-0.6585897803306580</left_val>
+            <right_val>0.0338787585496902</right_val></_></_>
+        <_>
+          <!-- tree 37 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 0 12 13 -1.</_>
+                <_>
+                  10 0 6 13 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0587356202304363</threshold>
+            <left_val>0.5156909227371216</left_val>
+            <right_val>-0.0378110408782959</right_val></_></_>
+        <_>
+          <!-- tree 38 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 0 3 3 -1.</_>
+                <_>
+                  5 0 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.1298059727996588e-003</threshold>
+            <left_val>0.0337678715586662</left_val>
+            <right_val>-0.7141758799552918</right_val></_></_>
+        <_>
+          <!-- tree 39 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  5 4 15 4 -1.</_>
+                <_>
+                  5 5 15 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.7763041220605373e-003</threshold>
+            <left_val>0.3170667886734009</left_val>
+            <right_val>-0.0705173835158348</right_val></_></_>
+        <_>
+          <!-- tree 40 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 4 1 4 -1.</_>
+                <_>
+                  3 5 1 2 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>6.3052959740161896e-003</threshold>
+            <left_val>0.0391417182981968</left_val>
+            <right_val>-0.5847613215446472</right_val></_></_>
+        <_>
+          <!-- tree 41 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  17 2 5 3 -1.</_>
+                <_>
+                  16 3 5 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>6.1587840318679810e-003</threshold>
+            <left_val>-0.0449264384806156</left_val>
+            <right_val>0.0717605873942375</right_val></_></_>
+        <_>
+          <!-- tree 42 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 2 2 1 -1.</_>
+                <_>
+                  1 2 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.2434650822542608e-005</threshold>
+            <left_val>0.1282729059457779</left_val>
+            <right_val>-0.1450162976980209</right_val></_></_>
+        <_>
+          <!-- tree 43 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 3 3 1 -1.</_>
+                <_>
+                  23 3 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>8.0436212010681629e-004</threshold>
+            <left_val>0.0332005806267262</left_val>
+            <right_val>-0.4817535877227783</right_val></_></_>
+        <_>
+          <!-- tree 44 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 0 3 4 -1.</_>
+                <_>
+                  5 1 1 4 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>7.0350770838558674e-003</threshold>
+            <left_val>-0.0684330388903618</left_val>
+            <right_val>0.3356839120388031</right_val></_></_>
+        <_>
+          <!-- tree 45 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 0 3 3 -1.</_>
+                <_>
+                  23 0 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.7437869682908058e-003</threshold>
+            <left_val>-0.5168190002441406</left_val>
+            <right_val>0.0387103892862797</right_val></_></_>
+        <_>
+          <!-- tree 46 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 0 3 3 -1.</_>
+                <_>
+                  1 0 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.3796039856970310e-003</threshold>
+            <left_val>-0.6027885079383850</left_val>
+            <right_val>0.0300148203969002</right_val></_></_>
+        <_>
+          <!-- tree 47 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  18 2 7 3 -1.</_>
+                <_>
+                  17 3 7 1 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-5.9628728777170181e-003</threshold>
+            <left_val>0.2122364938259125</left_val>
+            <right_val>-0.0623799487948418</right_val></_></_>
+        <_>
+          <!-- tree 48 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  7 2 3 7 -1.</_>
+                <_>
+                  8 3 1 7 3.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>7.8189922496676445e-003</threshold>
+            <left_val>-0.0830926969647408</left_val>
+            <right_val>0.2613323032855988</right_val></_></_>
+        <_>
+          <!-- tree 49 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 8 3 6 -1.</_>
+                <_>
+                  23 8 1 6 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.3976050801575184e-003</threshold>
+            <left_val>-0.7587574720382690</left_val>
+            <right_val>0.0219896193593740</right_val></_></_>
+        <_>
+          <!-- tree 50 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 8 3 6 -1.</_>
+                <_>
+                  1 8 1 6 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>3.8704490289092064e-003</threshold>
+            <left_val>0.0274105407297611</left_val>
+            <right_val>-0.6408017873764038</right_val></_></_>
+        <_>
+          <!-- tree 51 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 8 3 4 -1.</_>
+                <_>
+                  21 8 1 4 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-2.5311200879514217e-003</threshold>
+            <left_val>0.2538227140903473</left_val>
+            <right_val>-0.0790797770023346</right_val></_></_>
+        <_>
+          <!-- tree 52 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 7 3 1 -1.</_>
+                <_>
+                  5 7 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.5131019754335284e-003</threshold>
+            <left_val>0.0234907194972038</left_val>
+            <right_val>-0.8141220211982727</right_val></_></_>
+        <_>
+          <!-- tree 53 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 6 3 6 -1.</_>
+                <_>
+                  21 6 1 6 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.1154941059648991e-003</threshold>
+            <left_val>-0.0715807899832726</left_val>
+            <right_val>0.2275080978870392</right_val></_></_>
+        <_>
+          <!-- tree 54 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 6 3 6 -1.</_>
+                <_>
+                  3 6 1 6 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-2.3327460512518883e-003</threshold>
+            <left_val>0.2606957852840424</left_val>
+            <right_val>-0.0738020092248917</right_val></_></_>
+        <_>
+          <!-- tree 55 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 5 3 3 -1.</_>
+                <_>
+                  21 5 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-9.0139301028102636e-004</threshold>
+            <left_val>0.1801587045192719</left_val>
+            <right_val>-0.1048739999532700</right_val></_></_>
+        <_>
+          <!-- tree 56 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 3 3 2 -1.</_>
+                <_>
+                  1 3 1 2 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.0930569842457771e-003</threshold>
+            <left_val>0.0495798699557781</left_val>
+            <right_val>-0.3955506086349487</right_val></_></_>
+        <_>
+          <!-- tree 57 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 5 3 3 -1.</_>
+                <_>
+                  21 5 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>9.0298609575256705e-004</threshold>
+            <left_val>-0.0557567402720451</left_val>
+            <right_val>0.1339689046144486</right_val></_></_>
+        <_>
+          <!-- tree 58 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 5 3 3 -1.</_>
+                <_>
+                  3 5 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.2262780219316483e-003</threshold>
+            <left_val>-0.0803947225213051</left_val>
+            <right_val>0.2448578029870987</right_val></_></_>
+        <_>
+          <!-- tree 59 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 3 3 1 -1.</_>
+                <_>
+                  23 3 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.8188270041719079e-003</threshold>
+            <left_val>9.7458660602569580e-003</left_val>
+            <right_val>-0.8289809823036194</right_val></_></_>
+        <_>
+          <!-- tree 60 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 3 3 1 -1.</_>
+                <_>
+                  1 3 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.2358340104110539e-004</threshold>
+            <left_val>-0.3604617118835449</left_val>
+            <right_val>0.0581864602863789</right_val></_></_>
+        <_>
+          <!-- tree 61 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 4 3 3 -1.</_>
+                <_>
+                  21 4 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.8740149680525064e-003</threshold>
+            <left_val>0.1886530965566635</left_val>
+            <right_val>-0.0660941600799561</right_val></_></_>
+        <_>
+          <!-- tree 62 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 7 5 2 -1.</_>
+                <_>
+                  10 8 5 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.8799559911713004e-003</threshold>
+            <left_val>0.0807607918977737</left_val>
+            <right_val>-0.2298492044210434</right_val></_></_>
+        <_>
+          <!-- tree 63 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  21 0 4 2 -1.</_>
+                <_>
+                  22 1 2 2 2.</_></rects>
+              <tilted>1</tilted></feature>
+            <threshold>-7.4449679814279079e-003</threshold>
+            <left_val>-0.3741999864578247</left_val>
+            <right_val>0.0318274013698101</right_val></_></_>
+        <_>
+          <!-- tree 64 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  10 12 2 2 -1.</_>
+                <_>
+                  10 12 1 1 2.</_>
+                <_>
+                  11 13 1 1 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-7.2451919550076127e-004</threshold>
+            <left_val>0.2911868989467621</left_val>
+            <right_val>-0.0638798028230667</right_val></_></_>
+        <_>
+          <!-- tree 65 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  22 11 3 1 -1.</_>
+                <_>
+                  23 11 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>9.1002031695097685e-004</threshold>
+            <left_val>0.0387019403278828</left_val>
+            <right_val>-0.3980490863323212</right_val></_></_>
+        <_>
+          <!-- tree 66 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  9 14 3 1 -1.</_>
+                <_>
+                  10 14 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-6.4574118005111814e-004</threshold>
+            <left_val>0.2734352052211762</left_val>
+            <right_val>-0.0697167664766312</right_val></_></_>
+        <_>
+          <!-- tree 67 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  15 12 3 3 -1.</_>
+                <_>
+                  16 12 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>2.7163620106875896e-003</threshold>
+            <left_val>0.0256648194044828</left_val>
+            <right_val>-0.5053768754005432</right_val></_></_>
+        <_>
+          <!-- tree 68 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  0 11 3 1 -1.</_>
+                <_>
+                  1 11 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.7744099972769618e-004</threshold>
+            <left_val>-0.3803620934486389</left_val>
+            <right_val>0.0476176701486111</right_val></_></_>
+        <_>
+          <!-- tree 69 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  13 14 3 1 -1.</_>
+                <_>
+                  14 14 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.6855248617939651e-004</threshold>
+            <left_val>0.2071606963872910</left_val>
+            <right_val>-0.0830572172999382</right_val></_></_>
+        <_>
+          <!-- tree 70 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 8 3 1 -1.</_>
+                <_>
+                  12 8 1 1 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-3.0764768598601222e-004</threshold>
+            <left_val>-0.3448849022388458</left_val>
+            <right_val>0.0566739216446877</right_val></_></_>
+        <_>
+          <!-- tree 71 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 4 3 3 -1.</_>
+                <_>
+                  21 4 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>6.2692037317901850e-004</threshold>
+            <left_val>-0.0530941002070904</left_val>
+            <right_val>0.1083028018474579</right_val></_></_>
+        <_>
+          <!-- tree 72 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 4 3 3 -1.</_>
+                <_>
+                  3 4 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-1.6796359559521079e-003</threshold>
+            <left_val>0.2805620133876801</left_val>
+            <right_val>-0.0674557611346245</right_val></_></_>
+        <_>
+          <!-- tree 73 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  11 0 4 4 -1.</_>
+                <_>
+                  11 1 4 2 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-7.0166718214750290e-003</threshold>
+            <left_val>-0.5580223202705383</left_val>
+            <right_val>0.0335072018206120</right_val></_></_>
+        <_>
+          <!-- tree 74 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  4 0 15 6 -1.</_>
+                <_>
+                  4 3 15 3 2.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-0.0314981192350388</threshold>
+            <left_val>-0.3745109140872955</left_val>
+            <right_val>0.0480095781385899</right_val></_></_>
+        <_>
+          <!-- tree 75 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  20 3 3 3 -1.</_>
+                <_>
+                  21 3 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>-4.6240870142355561e-004</threshold>
+            <left_val>0.1198967024683952</left_val>
+            <right_val>-0.1037184968590736</right_val></_></_>
+        <_>
+          <!-- tree 76 -->
+          <_>
+            <!-- root node -->
+            <feature>
+              <rects>
+                <_>
+                  2 3 3 3 -1.</_>
+                <_>
+                  3 3 1 3 3.</_></rects>
+              <tilted>0</tilted></feature>
+            <threshold>1.3164649717509747e-003</threshold>
+            <left_val>-0.0710325986146927</left_val>
+            <right_val>0.2680436968803406</right_val></_></_></trees>
+      <stage_threshold>-1.3202420473098755</stage_threshold>
+      <parent>13</parent>
+      <next>-1</next></_></stages></Nariz_15stages>
+</opencv_storage>


### PR DESCRIPTION
> face detected using landmark model -> alert
since faces are detected if at least a nose is exposed.

> two eyes detected -> mouth/nose should be near the perpendicular line that extends from the middle point of the eyes
also, the distance from the mouth and one eye should be larger than the distance between the two eyes

> one eye detected -> mouth and nose should be lower than the eye

* further possible improvement
run cascade with smaller input using the position of two eyes - speed
invalidating too small or too big detection
NMS to simplify the output
making it work on multiple faces

* mac users should change the following line
cap = cv2.VideoCapture(0, cv2.CAP_DSHOW)
to
cap = cv2.VideoCapture(0)

pylint passed